### PR TITLE
Changed TryGuessCidr to Return Full CIDR

### DIFF
--- a/src/System.Net.IPNetwork/IPNetwork.cs
+++ b/src/System.Net.IPNetwork/IPNetwork.cs
@@ -1754,17 +1754,12 @@ namespace System.Net
 #region TryGuessCidr
 
         /// <summary>
-        /// 
-        /// Class              Leading bits    Default netmask
-        ///     A (CIDR /8)	       00           255.0.0.0
-        ///     A (CIDR /8)	       01           255.0.0.0
-        ///     B (CIDR /16)	   10           255.255.0.0
-        ///     C (CIDR /24)       11 	        255.255.255.0
-        ///  
+        /// Assume default CIDR is for a single IP address. AKA not an IP network at all.
+        /// If this is the case, the user should probably be using <see cref="IPAddress"/> instead of <see cref="IPNetwork"/>.
         /// </summary>
-        /// <param name="ip"></param>
-        /// <param name="cidr"></param>
-        /// <returns></returns>
+        /// <param name="ip">IP address to guess CIDR for.</param>
+        /// <param name="cidr">Our parameter with resulting CIDR.</param>
+        /// <returns>Returns the default full CIDR for the IP protocol.</returns>
         public static bool TryGuessCidr(string ip, out byte cidr) {
 
             IPAddress ipaddress = null;
@@ -1775,19 +1770,11 @@ namespace System.Net
             }
 
             if (ipaddress.AddressFamily == AddressFamily.InterNetworkV6) {
-                cidr = 64;
+                cidr = 128;
                 return true;
             }
-            BigInteger uintIPAddress = IPNetwork.ToBigInteger(ipaddress);
-            uintIPAddress = uintIPAddress >> 29;
-            if (uintIPAddress <= 3) {
-                cidr = 8;
-                return true;
-            } else if (uintIPAddress <= 5) {
-                cidr = 16;
-                return true;
-            } else if (uintIPAddress <= 6) {
-                cidr = 24;
+            else if (ipaddress.AddressFamily == AddressFamily.InterNetworkV4)
+                cidr = 32;
                 return true;
             }
 


### PR DESCRIPTION
Changed [`TryGuessCidr(string ip, out byte cidr)`](https://github.com/lduchosal/ipnetwork/blob/90fc1f09b2fca73319c3345e848dcebb5f14bcf8/src/System.Net.IPNetwork/IPNetwork.cs#L1768) to return 32 for IPv4 and 128 for IPv6.

Fixes #29 

As I mentioned in #29, this makes more sense from a network engineer point of view. an IP address with no network mask or CIDR is always assumed to be a single IP address and not an IP network, so therefore defaulting to 32 for IPv4 and 128 for IPv6 makes more sense.

This could be a breaking change for the very few people that might be using [`Parse(string network)`](https://github.com/lduchosal/ipnetwork/blob/90fc1f09b2fca73319c3345e848dcebb5f14bcf8/src/System.Net.IPNetwork/IPNetwork.cs#L261) or [`TryParse(string network, out IPNetwork ipnetwork)`](https://github.com/lduchosal/ipnetwork/blob/90fc1f09b2fca73319c3345e848dcebb5f14bcf8/src/System.Net.IPNetwork/IPNetwork.cs#L337). But I highly doubt this is a big issue.

The argument can however be made that it makes no since for `IPNetwork.Parse` even has an overload with no network mask or CIDR. So it might be a more logical change to straight out remove [`Parse(string network)`](https://github.com/lduchosal/ipnetwork/blob/90fc1f09b2fca73319c3345e848dcebb5f14bcf8/src/System.Net.IPNetwork/IPNetwork.cs#L261) and [`TryParse(string network, out IPNetwork ipnetwork)`](https://github.com/lduchosal/ipnetwork/blob/90fc1f09b2fca73319c3345e848dcebb5f14bcf8/src/System.Net.IPNetwork/IPNetwork.cs#L337), since making a IP network without a network mask or CIDR makes no sense. If you don't have a network mask or CIDR you should be using `IPAddress.Parse` instead.

Thoughts? Feedback?