### PR TITLE
Fix datacontract serialization

### DIFF
--- a/src/System.Net.IPNetwork.TestProject.NetFramework/System.Net.IPNetwork.TestProject.NetFramework.csproj
+++ b/src/System.Net.IPNetwork.TestProject.NetFramework/System.Net.IPNetwork.TestProject.NetFramework.csproj
@@ -38,8 +38,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/System.Net.IPNetwork.TestProject.NetFramework/System.Net.IPNetwork.TestProject.NetFramework.csproj
+++ b/src/System.Net.IPNetwork.TestProject.NetFramework/System.Net.IPNetwork.TestProject.NetFramework.csproj
@@ -48,6 +48,7 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/System.Net.IPNetwork.TestProject.Source/SerializeDataContractTest.cs
+++ b/src/System.Net.IPNetwork.TestProject.Source/SerializeDataContractTest.cs
@@ -1,0 +1,73 @@
+﻿using System.IO;
+using System.Runtime.Serialization;
+using System.Xml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Net.TestSerialization.NetFramework
+{
+    public static class DataContractSerializeHelper
+    {
+        public static string Serialize<T>(T obj, bool formatting = true) where T : new()
+        {
+            if (obj == null)
+                return string.Empty;
+
+            var serializer = new DataContractSerializer(typeof(T));
+            var settings = new XmlWriterSettings
+            {
+                OmitXmlDeclaration = true,
+                Indent = formatting
+            };
+            using (var textWriter = new StringWriter())
+            {
+                using (var xmlWriter = XmlWriter.Create(textWriter, settings))
+                {
+                    serializer.WriteObject(xmlWriter, obj);
+                }
+
+                var result = textWriter.ToString();
+                return result;
+            }
+        }
+
+        public static T Deserialize<T>(string xml) where T : new()
+        {
+            if (string.IsNullOrWhiteSpace(xml))
+                return new T();
+
+            using (var textReader = new StringReader(xml))
+            using (var xmlReader = XmlReader.Create(textReader))
+            {
+                var serializer = new DataContractSerializer(typeof(T));
+                var result = (T) serializer.ReadObject(xmlReader);
+                return result;
+            }
+        }
+    }
+
+    [TestClass]
+    public class SerializeDataContractTest
+    {
+        [TestMethod]
+        public void Test_Serialize_DataContract()
+        {
+            var ipnetwork = IPNetwork.Parse("10.0.0.1/8");
+
+            string result = DataContractSerializeHelper.Serialize(ipnetwork);
+        
+            string expected = $"<IPNetwork xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:x=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://schemas.datacontract.org/2004/07/System.Net\">{Environment.NewLine}  <IPNetwork i:type=\"x:string\" xmlns=\"\">10.0.0.0/8</IPNetwork>{Environment.NewLine}</IPNetwork>";
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void Test_Deserialize_DataContract()
+        {
+            var ipnetwork = IPNetwork.Parse("10.0.0.1/8");
+            string serialized = DataContractSerializeHelper.Serialize(ipnetwork);
+            
+            var result = DataContractSerializeHelper.Deserialize<IPNetwork>(serialized);
+            
+            Assert.AreEqual(ipnetwork, result);
+        }
+    }
+}

--- a/src/System.Net.IPNetwork.TestProject.Source/SerializeXmlTest.cs
+++ b/src/System.Net.IPNetwork.TestProject.Source/SerializeXmlTest.cs
@@ -24,10 +24,7 @@ namespace System.Net.TestSerialization.NetFramework
 
             var result = Encoding.UTF8.GetString(mem.ToArray());
 
-            string expected = @"<?xml version=""1.0""?>
-<IPNetwork xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
-  <Value>10.0.0.0/8</Value>
-</IPNetwork>";
+            string expected = $@"<?xml version=""1.0""?>{Environment.NewLine}<IPNetwork xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">{Environment.NewLine}  <Value>10.0.0.0/8</Value>{Environment.NewLine}</IPNetwork>";
             Assert.AreEqual(expected, result);
         }
 

--- a/src/System.Net.IPNetwork.TestProject.Source/System.Net.IPNetwork.TestProject.Source.projitems
+++ b/src/System.Net.IPNetwork.TestProject.Source/System.Net.IPNetwork.TestProject.Source.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)IPNetworkUnitTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IPNetworkV6UnitTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SerializeBinaryFormatterTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SerializeDataContractTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SerializeJsonTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SerializeXmlTest.cs" />
   </ItemGroup>

--- a/src/System.Net.IPNetwork/IPNetwork.cs
+++ b/src/System.Net.IPNetwork/IPNetwork.cs
@@ -11,8 +11,7 @@ namespace System.Net
     /// <summary>
     /// IP Network utility class. 
     /// Use IPNetwork.Parse to create instances.
-    /// </summary>
-    [DataContract]
+    /// </summary> 
     [Serializable]
     public sealed class IPNetwork : IComparable<IPNetwork>, ISerializable {
 
@@ -1983,7 +1982,7 @@ namespace System.Net
 
         #region XmlSerialization
 
-        IPNetwork() { }
+        public IPNetwork() { }
 
         #endregion
 


### PR DESCRIPTION
For DataContract serialization, there is a need for only one of the [Serializable] & [DataContract] attributes and the public parameterless constructor existing.

