### PR TITLE
Fixed enumeration on IPAddressCollection

### DIFF
--- a/src/System.Net.IPNetwork/IPAddressCollection.cs
+++ b/src/System.Net.IPNetwork/IPAddressCollection.cs
@@ -14,8 +14,8 @@ namespace System.Net
     public class IPAddressCollection : IEnumerable<IPAddress>, IEnumerator<IPAddress> {
 
         private readonly IPNetwork _ipnetwork;
-        private BigInteger _enumerator;
         private readonly FilterEnum _filter;
+        private BigInteger _enumerator;
 
         internal IPAddressCollection(IPNetwork ipnetwork, FilterEnum filter) {
             this._ipnetwork = ipnetwork;
@@ -25,7 +25,6 @@ namespace System.Net
 
 
         #region Count, Array, Enumerator
-
         public BigInteger Count {
             get {
 
@@ -62,54 +61,89 @@ namespace System.Net
 
         #endregion
 
-        #region IEnumerable Members
-
-        IEnumerator<IPAddress> IEnumerable<IPAddress>.GetEnumerator() {
-            return this;
-        }
-
-        IEnumerator IEnumerable.GetEnumerator() {
-            return this;
-        }
-
-        #region IEnumerator<IPNetwork> Members
-
+        #region Legacy Enumeration
         public IPAddress Current {
-            get { return this[this._enumerator]; }
+            get {
+                return this[_enumerator];
+            }
         }
-
-        #endregion
-
-        #region IDisposable Members
-
-        public void Dispose() {
-            // nothing to dispose
-            return;
-        }
-
-        #endregion
-
-        #region IEnumerator Members
 
         object IEnumerator.Current {
-            get { return this.Current; }
+            get {
+                return Current;
+            }
         }
 
-        public bool MoveNext() {
-            this._enumerator++;
-            if (this._enumerator >= this.Count) {
+        public bool MoveNext()
+        {
+            _enumerator++;
+            if (_enumerator >= this.Count) {
                 return false;
             }
             return true;
-
         }
 
-        public void Reset() {
-            this._enumerator = -1;
+        public void Reset()
+        {
+            _enumerator = -1;
         }
 
+        public void Dispose()
+        {
+            // nothing to dispose
+        }
         #endregion
 
+        #region Enumeration
+        IEnumerator<IPAddress> IEnumerable<IPAddress>.GetEnumerator() {
+            return new Enumerator(this);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return new Enumerator(this);
+        }
+
+        struct Enumerator : IEnumerator<IPAddress>
+        {
+            private readonly IPAddressCollection _collection;
+            private BigInteger _enumerator;
+
+            object IEnumerator.Current {
+                get {
+                    return Current;
+                }
+            }
+
+            public IPAddress Current {
+                get {
+                    return _collection[_enumerator];
+                }
+            }
+
+            void IDisposable.Dispose()
+            {
+                // nothing to dispose
+            }
+
+            bool IEnumerator.MoveNext()
+            {
+                _enumerator++;
+                if (_enumerator >= _collection.Count) {
+                    return false;
+                }
+                return true;
+            }
+
+            void IEnumerator.Reset()
+            {
+                _enumerator = -1;
+            }
+
+            public Enumerator(IPAddressCollection collection)
+            {
+                _collection = collection;
+            }
+        }
         #endregion
     }
 }

--- a/src/System.Net.IPNetwork/IPAddressCollection.cs
+++ b/src/System.Net.IPNetwork/IPAddressCollection.cs
@@ -120,12 +120,12 @@ namespace System.Net
                 }
             }
 
-            void IDisposable.Dispose()
+            public void Dispose()
             {
                 // nothing to dispose
             }
 
-            bool IEnumerator.MoveNext()
+            public bool MoveNext()
             {
                 _enumerator++;
                 if (_enumerator >= _collection.Count) {
@@ -134,14 +134,15 @@ namespace System.Net
                 return true;
             }
 
-            void IEnumerator.Reset()
+            public void Reset()
             {
                 _enumerator = -1;
             }
 
             public Enumerator(IPAddressCollection collection)
             {
-                _collection = collection;
+                 _collection = collection;
+                Reset();
             }
         }
         #endregion

--- a/src/System.Net.IPNetwork/IPAddressCollection.cs
+++ b/src/System.Net.IPNetwork/IPAddressCollection.cs
@@ -141,8 +141,8 @@ namespace System.Net
 
             public Enumerator(IPAddressCollection collection)
             {
-                 _collection = collection;
-                Reset();
+                _collection = collection;
+                _enumerator = -1;
             }
         }
         #endregion


### PR DESCRIPTION
Found an issue when attempting to iterate `IPAddressCollection` more than once as an IEnumerable.

The old enumeration returned the same enumerator (itself) in subsequent calls, meaning a foreach loop will only work once. This commit still allows the legacy behaviour for backwards compatability, but returns a new enumerator for each `GetEnumerator` call. This allows multiple foreach/iterations and fullfils the `GetEnumerator` contract better.

You can replicate the issue with this code.

```csharp
IPNetwork network = IPNetwork.Parse("10.0.0.1/24");
IPAddressCollection collection = network.ListIPAddress();

// will iterate all addresses successfully
foreach(var addr in collection) {
	Console.WriteLine(addr);
}

// will not iterate
foreach(var addr in collection) {
	Console.WriteLine(addr);
}
```