### PR TITLE
IPNetwork.Contains improvements

### DIFF
--- a/src/System.Net.IPNetwork/IPNetwork.cs
+++ b/src/System.Net.IPNetwork/IPNetwork.cs
@@ -96,6 +96,14 @@ namespace System.Net
             }
         }
 
+        private BigInteger CreateBroadcast(ref BigInteger network)
+        {
+            int width = this._family == Sockets.AddressFamily.InterNetwork ? 4 : 16;
+            BigInteger uintBroadcast = network + this._netmask.PositiveReverse(width);
+
+            return uintBroadcast;
+        }
+
         /// <summary>
         /// Broadcast address
         /// </summary>
@@ -1090,7 +1098,7 @@ namespace System.Net
             }
 
             BigInteger uintNetwork = _network;
-            BigInteger uintBroadcast = _broadcast;
+            BigInteger uintBroadcast = CreateBroadcast(ref uintNetwork);
             BigInteger uintAddress = IPNetwork.ToBigInteger(ipaddress);
 
             bool contains = (uintAddress >= uintNetwork

--- a/src/System.Net.IPNetwork/IPNetwork.cs
+++ b/src/System.Net.IPNetwork/IPNetwork.cs
@@ -666,6 +666,17 @@ namespace System.Net
             }
 
             byte[] bytes = ipaddress.GetAddressBytes();
+#if NET45 || NET46 || NET47 || NETSTANDARD20
+            bytes.AsSpan().Reverse();
+#else
+            Array.Reverse(bytes);
+#endif
+
+            // add trailing 0 to make unsigned
+            var unsigned = new byte[bytes.Length + 1];
+            Buffer.BlockCopy(bytes, 0, unsigned, 0, bytes.Length);
+            uintIpAddress = new BigInteger(unsigned);
+
             /// 20180217 lduchosal
             /// code impossible to reach, GetAddressBytes returns either 4 or 16 bytes length addresses
             /// if (bytes.Length != 4 && bytes.Length != 16) {
@@ -675,12 +686,6 @@ namespace System.Net
             ///     uintIpAddress = null;
             ///     return;
             /// }
-            
-            Array.Reverse(bytes);
-            var unsigned = new List<byte>(bytes);
-            unsigned.Add(0);
-            uintIpAddress = new BigInteger(unsigned.ToArray());
-            return;
         }
 
 
@@ -1105,7 +1110,6 @@ namespace System.Net
                 && uintAddress <= uintBroadcast);
 
             return contains;
-            
         }
 
         [Obsolete("static Contains is deprecated, please use instance Contains.")]

--- a/src/System.Net.IPNetwork/IPNetwork.cs
+++ b/src/System.Net.IPNetwork/IPNetwork.cs
@@ -96,10 +96,10 @@ namespace System.Net
             }
         }
 
-        private BigInteger CreateBroadcast(ref BigInteger network)
+        static BigInteger CreateBroadcast(ref BigInteger network, BigInteger netmask, AddressFamily family)
         {
-            int width = this._family == Sockets.AddressFamily.InterNetwork ? 4 : 16;
-            BigInteger uintBroadcast = network + this._netmask.PositiveReverse(width);
+            int width = family == AddressFamily.InterNetwork ? 4 : 16;
+            BigInteger uintBroadcast = network + netmask.PositiveReverse(width);
 
             return uintBroadcast;
         }
@@ -1113,7 +1113,7 @@ namespace System.Net
             }
 
             BigInteger uintNetwork = _network;
-            BigInteger uintBroadcast = CreateBroadcast(ref uintNetwork);
+            BigInteger uintBroadcast = CreateBroadcast(ref uintNetwork, this._netmask, this._family);
             BigInteger uintAddress = IPNetwork.ToBigInteger(ipaddress);
 
             bool contains = (uintAddress >= uintNetwork
@@ -1146,10 +1146,10 @@ namespace System.Net
             }
 
             BigInteger uintNetwork = _network;
-            BigInteger uintBroadcast = CreateBroadcast(ref uintNetwork);
+            BigInteger uintBroadcast = CreateBroadcast(ref uintNetwork, this._netmask, this._family);
 
             BigInteger uintFirst = network2._network;
-            BigInteger uintLast = CreateBroadcast(ref uintFirst);
+            BigInteger uintLast = CreateBroadcast(ref uintFirst, network2._netmask, network2._family);
 
             bool contains = (uintFirst >= uintNetwork
                 && uintLast <= uintBroadcast);

--- a/src/System.Net.IPNetwork/IPNetwork.cs
+++ b/src/System.Net.IPNetwork/IPNetwork.cs
@@ -1139,6 +1139,7 @@ namespace System.Net
         /// <param name="network2"></param>
         /// <returns></returns>
         public bool Contains(IPNetwork network2) {
+
             if (network2 == null)
             {
                 throw new ArgumentNullException("network2");

--- a/src/System.Net.IPNetwork/IPNetwork.cs
+++ b/src/System.Net.IPNetwork/IPNetwork.cs
@@ -1139,17 +1139,16 @@ namespace System.Net
         /// <param name="network2"></param>
         /// <returns></returns>
         public bool Contains(IPNetwork network2) {
-
             if (network2 == null)
             {
                 throw new ArgumentNullException("network2");
             }
 
             BigInteger uintNetwork = _network;
-            BigInteger uintBroadcast = _broadcast;
+            BigInteger uintBroadcast = CreateBroadcast(ref uintNetwork);
 
             BigInteger uintFirst = network2._network;
-            BigInteger uintLast = network2._broadcast;
+            BigInteger uintLast = CreateBroadcast(ref uintFirst);
 
             bool contains = (uintFirst >= uintNetwork
                 && uintLast <= uintBroadcast);

--- a/src/System.Net.IPNetwork/System.Net.IPNetwork.csproj
+++ b/src/System.Net.IPNetwork/System.Net.IPNetwork.csproj
@@ -67,6 +67,12 @@
     </PackageReference>
   </ItemGroup>
   
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Memory">
+      <Version>4.5.4</Version>
+    </PackageReference>
+  </ItemGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <PackageReference Include="System.Memory">
       <Version>4.5.4</Version>
@@ -80,6 +86,12 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
+    <PackageReference Include="System.Memory">
+      <Version>4.5.4</Version>
+    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net50'">
     <PackageReference Include="System.Memory">
       <Version>4.5.4</Version>
     </PackageReference>

--- a/src/System.Net.IPNetwork/System.Net.IPNetwork.csproj
+++ b/src/System.Net.IPNetwork/System.Net.IPNetwork.csproj
@@ -54,4 +54,34 @@
     <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <PackageReference Include="System.Memory">
+      <Version>4.5.4</Version>
+    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory">
+      <Version>4.5.4</Version>
+    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="System.Memory">
+      <Version>4.5.4</Version>
+    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <PackageReference Include="System.Memory">
+      <Version>4.5.4</Version>
+    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
+    <PackageReference Include="System.Memory">
+      <Version>4.5.4</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/System.Net.IPNetwork/System.Net.IPNetwork.csproj
+++ b/src/System.Net.IPNetwork/System.Net.IPNetwork.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net40;net45;net46;net47</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.6;netstandard2.0</TargetFrameworks> 
+    <TargetFrameworks>netstandard1.6;netstandard2.0;netstandard2.1;net40;net45;net46;net47;net50</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.6;netstandard2.0;netstandard2.1;net50</TargetFrameworks> 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 	  <PackageId>IPNetwork2</PackageId>
     <PackageVersion>2.4.0</PackageVersion>


### PR DESCRIPTION
This PR improves `IPNetwork.Contains(IPAddress)` and `IPNetwork.Contains(IPNetwork)` methods both in performance and memory allocations. Also adds .NET 5.0 and .NET Standard 2.1 targets which use constructor for `BigInteger` the removes array allocations and array reversal. For platforms that support `Span<T>` uses that method to reverse the array.

|                    Method |     Mean |    Error |   StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------- |---------:|---------:|---------:|------:|-------:|------:|------:|----------:|
| 'Contains(IPAddress) - main | 801.1 ns | 15.67 ns | 26.18 ns |  1.00 | 0.0801 |     - |     - |     421 B |
| 'Contains(IPAddress) - next | 475.1 ns |  9.35 ns | 18.68 ns |  1.00 | 0.0515 |     - |     - |     272 B |
|                              |            |          |          |       |        |       |       |           |
| 'Contains(IPNetwork) - main | 1,064.8 ns | 21.31 ns | 49.38 ns |  1.00 | 0.1221 |     - |     - |     649 B |
| 'Contains(IPNetwork) - next |   759.1 ns | 15.00 ns | 28.90 ns |  1.00 | 0.0896 |     - |     - |     473 B |