### PR TITLE
Reduce allocations for BigInteger.PositiveReverse

### DIFF
--- a/src/System.Net.IPNetwork/BigIntegerExt.cs
+++ b/src/System.Net.IPNetwork/BigIntegerExt.cs
@@ -140,18 +140,25 @@ namespace System.Net
         /// <param name="width"></param>
         /// <returns></returns>
         public static BigInteger PositiveReverse(this BigInteger input, int width) {
-
-            var result = new List<byte>();
             var bytes = input.ToByteArray();
-            var work = new byte[width];
-            Array.Copy(bytes, 0, work, 0, bytes.Length - 1); // Length -1 : positive BigInteger
+            var length = width + 1;
 
-            for (int i = 0; i < work.Length; i++) {
-                result.Add((byte)(~work[i]));
+            // if the byte array is same size as output, we'll perform the operations in place
+            var output = bytes.Length != length ? new byte[length] : bytes;
+
+            // invert all of the source bytes
+            for (var i = 0; i < bytes.Length - 1; i++) {
+                output[i] = (byte)~bytes[i];
             }
-            result.Add(0); // positive BigInteger
-            return new BigInteger(result.ToArray());
 
+            // invert the remainder of the output buffer
+            for (var i = bytes.Length - 1; i < output.Length - 1; i++) {
+                output[i] = byte.MaxValue;
+            }
+
+            // ensure output value is positive and return
+            output[output.Length - 1] = 0;
+            return new BigInteger(output);
         }
     }
 }


### PR DESCRIPTION
1. When possible, do operations in place on same array that is returned from `BigInteger`
2. remove duplicate list allocation + array allocation
3. ensure all allocations fixed size

Performance is about 35% faster and memory allocations are reduced by 31%

|      Method |     Mean |   Error |  StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |---------:|--------:|--------:|------:|-------:|------:|------:|----------:|
|  OriginalV4 | 166.1 ns | 2.01 ns | 1.78 ns |  1.00 | 0.0319 |     - |     - |     168 B |
|  OriginalV6 | 177.4 ns | 3.57 ns | 6.71 ns |  1.00 | 0.0319 |     - |     - |     168 B |
|             |          |         |         |       |        |       |       |           |
| OptimizedV4 | 109.6 ns | 1.99 ns | 1.76 ns |  1.00 | 0.0219 |     - |     - |     116 B |
| OptimizedV6 | 109.8 ns | 2.19 ns | 2.05 ns |  1.00 | 0.0221 |     - |     - |     116 B |