### PR TITLE
Add bulk api for checking networks if they contain an ip address

### DIFF
--- a/src/System.Net.IPNetwork/IPNetwork.cs
+++ b/src/System.Net.IPNetwork/IPNetwork.cs
@@ -1168,7 +1168,78 @@ namespace System.Net
             return network.Contains(network2);
         }
 
-#endregion
+        /// <summary>
+        /// Determines if any of the specified <paramref name="networks"/> contains the given <paramref name="address"/>
+        /// </summary>
+        /// <param name="networks">A list of networks to check</param>
+        /// <param name="address">The ip address to check</param>
+        /// <returns><c>true</c> if any of the networks contains the address; otherwise <c>false</c></returns>
+        public static bool Contains(IPNetwork[] networks, IPAddress address) {
+            if (address == null) {
+                throw new ArgumentNullException("ipaddress");
+            }
+
+            if (networks == null) {
+                throw new ArgumentNullException("networks");
+            }
+
+            // empty set, can't contain
+            if (networks.Length == 0) {
+                return false;
+            }
+
+            BigInteger uintAddress = IPNetwork.ToBigInteger(address);
+
+            foreach (var network in networks)
+            {
+                if (address.AddressFamily != network.AddressFamily)
+                    continue;
+
+                BigInteger uintNetwork = network._network;
+                BigInteger uintBroadcast = CreateBroadcast(ref uintNetwork, network._netmask, network._family);
+
+                if (uintAddress >= uintNetwork && uintAddress <= uintBroadcast) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determines if any of the specified <paramref name="networks"/> contains the given <paramref name="address"/>
+        /// </summary>
+        /// <param name="networks">A list of networks to check</param>
+        /// <param name="address">The ip address to check</param>
+        /// <returns><c>true</c> if any of the networks contains the address; otherwise <c>false</c></returns>
+        public static bool Contains(IEnumerable<IPNetwork> networks, IPAddress address)
+        {
+            if (address == null) {
+                throw new ArgumentNullException("ipaddress");
+            }
+
+            if (networks == null) {
+                throw new ArgumentNullException("networks");
+            }
+
+            BigInteger uintAddress = IPNetwork.ToBigInteger(address);
+
+            foreach (var network in networks) {
+                if (address.AddressFamily != network.AddressFamily)
+                    continue;
+
+                BigInteger uintNetwork = network._network;
+                BigInteger uintBroadcast = CreateBroadcast(ref uintNetwork, network._netmask, network._family);
+
+                if (uintAddress >= uintNetwork && uintAddress <= uintBroadcast) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        #endregion
 
 #region overlap
 


### PR DESCRIPTION
Improves performance and reduces allocations in the scenario for checking one address against many `IPNetwork` instances. Effectively saves ~36 bytes for each network that is checked, how many nanoseconds saved per invocation is harder to pin down. Savings come purely from just caching the numerical value of the IPAddress (benchmarks are ipv4 values only, ipv6 may have larger gains).

|       Method |       Mean |    Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------- |-----------:|---------:|----------:|------:|-------:|------:|------:|----------:|
|   Contains x 1 |   458.5 ns |  7.92 ns |   7.02 ns |  1.00 | 0.0553 |     - |     - |     292 B |
|              |            |          |           |       |        |       |       |           |
|  Original Contains x 2 |   920.8 ns | 18.15 ns |  17.83 ns |  1.00 | 0.1106 |     - |     - |     585 B |
| Optimized Contains x 2 |   830.9 ns | 15.73 ns |  14.72 ns |  1.00 | 0.1040 |     - |     - |     549 B |
|              |            |          |           |       |        |       |       |           |
|  Original Contains x 10 | 4,377.9 ns | 31.78 ns |  26.54 ns |  1.00 | 0.5264 |     - |     - |    2764 B |
| Optimized Contains x 10 | 3,741.4 ns | 69.03 ns | 117.23 ns |  1.00 | 0.4616 |     - |     - |    2440 B |