### PR TITLE
Added public ctor, removed Parse

### DIFF
--- a/src/System.Net.IPNetwork/IPNetwork.cs
+++ b/src/System.Net.IPNetwork/IPNetwork.cs
@@ -264,25 +264,6 @@ namespace System.Net
         }
 
         /// <summary>
-        /// 192.168.168.100/24
-        /// 
-        /// Network   : 192.168.168.0
-        /// Netmask   : 255.255.255.0
-        /// Cidr      : 24
-        /// Start     : 192.168.168.1
-        /// End       : 192.168.168.254
-        /// Broadcast : 192.168.168.255
-        /// </summary>
-        /// <param name="ipaddress"></param>
-        /// <param name="cidr"></param>
-        /// <returns></returns>
-        public static IPNetwork Parse(IPAddress ipaddress, byte cidr) {
-            IPNetwork ipnetwork = null;
-            IPNetwork.InternalParse(false, ipaddress, cidr, out ipnetwork);
-            return ipnetwork;
-        }
-
-        /// <summary>
         /// 192.168.168.100 255.255.255.0
         /// 
         /// Network   : 192.168.168.0
@@ -646,44 +627,7 @@ namespace System.Net
 
             IPNetwork.InternalParse(tryParse, ip, mask, out ipnetwork);
         }
-
-        /// <summary>
-        /// 192.168.168.100/24
-        /// 
-        /// Network   : 192.168.168.0
-        /// Netmask   : 255.255.255.0
-        /// Cidr      : 24
-        /// Start     : 192.168.168.1
-        /// End       : 192.168.168.254
-        /// Broadcast : 192.168.168.255
-        /// </summary>
-        /// <param name="ipaddress"></param>
-        /// <param name="cidr"></param>
-        /// <returns></returns>
-        private static void InternalParse(bool tryParse, IPAddress ipaddress, byte cidr, out IPNetwork ipnetwork) {
-            if (ipaddress == null)
-            {
-                if (tryParse == false)
-                {
-                    throw new ArgumentNullException("ipaddress");
-                }
-                ipnetwork = null;
-                return;
-            }
-
-            IPAddress mask = null;
-            bool parsedNetmask = IPNetwork.TryToNetmask(cidr, ipaddress.AddressFamily, out mask);
-            if (parsedNetmask == false) {
-                if (tryParse == false) {
-                    throw new ArgumentException("cidr");
-                }
-                ipnetwork = null;
-                return;
-            }
-            
-            IPNetwork.InternalParse(tryParse, ipaddress, mask, out ipnetwork);
-        }
-
+        
 #endregion
 
 #region converters

--- a/src/System.Net.IPNetwork/IPNetwork.cs
+++ b/src/System.Net.IPNetwork/IPNetwork.cs
@@ -188,23 +188,36 @@ namespace System.Net
 #else
         internal
 #endif
+            IPNetwork(BigInteger ipaddress, AddressFamily family, byte cidr)
+        {
+            Init(ipaddress, family, cidr);
+        }
 
-        IPNetwork(BigInteger ipaddress, AddressFamily family, byte cidr) {
+        public IPNetwork(IPAddress ipaddress, byte cidr)
+        {
+            if (ipaddress == null) throw new ArgumentNullException(nameof(ipaddress));
 
-            int maxCidr = family == Sockets.AddressFamily.InterNetwork ? 32 : 128;
-            if (cidr > maxCidr) {
+            var uintIpAddress = ToBigInteger(ipaddress);
+
+            Init(uintIpAddress, ipaddress.AddressFamily, cidr);
+        }
+
+        private void Init(BigInteger ipaddress, AddressFamily family, byte cidr)
+        {
+            var maxCidr = family == AddressFamily.InterNetwork ? 32 : 128;
+            if (cidr > maxCidr)
+            {
                 throw new ArgumentOutOfRangeException("cidr");
             }
 
-            this._ipaddress = ipaddress;
-            this._family = family;
-            this._cidr = cidr;
-
+            _ipaddress = ipaddress;
+            _family = family;
+            _cidr = cidr;
         }
 
 #endregion
 
-#region parsers
+        #region parsers
 
         /// <summary>
         /// 192.168.168.100 - 255.255.255.0

--- a/src/System.Net.IPNetwork/IPNetwork.cs
+++ b/src/System.Net.IPNetwork/IPNetwork.cs
@@ -251,6 +251,27 @@ namespace System.Net
         }
 
         /// <summary>
+        /// 192.168.168.100/24
+        /// 
+        /// Network   : 192.168.168.0
+        /// Netmask   : 255.255.255.0
+        /// Cidr      : 24
+        /// Start     : 192.168.168.1
+        /// End       : 192.168.168.254
+        /// Broadcast : 192.168.168.255
+        /// </summary>
+        /// <param name="ipaddress"></param>
+        /// <param name="cidr"></param>
+        /// <returns></returns>
+        public static IPNetwork Parse(IPAddress ipaddress, byte cidr) {
+
+            IPNetwork ipnetwork = null;
+            IPNetwork.InternalParse(false, ipaddress, cidr, out ipnetwork);
+            return ipnetwork;
+
+        }
+
+        /// <summary>
         /// 192.168.168.100 255.255.255.0
         /// 
         /// Network   : 192.168.168.0
@@ -613,6 +634,44 @@ namespace System.Net
 
 
             IPNetwork.InternalParse(tryParse, ip, mask, out ipnetwork);
+        }
+
+        /// <summary>
+        /// 192.168.168.100/24
+        /// 
+        /// Network   : 192.168.168.0
+        /// Netmask   : 255.255.255.0
+        /// Cidr      : 24
+        /// Start     : 192.168.168.1
+        /// End       : 192.168.168.254
+        /// Broadcast : 192.168.168.255
+        /// </summary>
+        /// <param name="ipaddress"></param>
+        /// <param name="cidr"></param>
+        /// <returns></returns>
+        private static void InternalParse(bool tryParse, IPAddress ipaddress, byte cidr, out IPNetwork ipnetwork) {
+
+            if (ipaddress == null)
+            {
+                if (tryParse == false)
+                {
+                    throw new ArgumentNullException("ipaddress");
+                }
+                ipnetwork = null;
+                return;
+            }
+
+            IPAddress mask = null;
+            bool parsedNetmask = IPNetwork.TryToNetmask(cidr, ipaddress.AddressFamily, out mask);
+            if (parsedNetmask == false) {
+                if (tryParse == false) {
+                    throw new ArgumentException("cidr");
+                }
+                ipnetwork = null;
+                return;
+            }
+            
+            IPNetwork.InternalParse(tryParse, ipaddress, mask, out ipnetwork);
         }
 
 #endregion

--- a/src/System.Net.IPNetwork/IPNetwork.cs
+++ b/src/System.Net.IPNetwork/IPNetwork.cs
@@ -264,11 +264,9 @@ namespace System.Net
         /// <param name="cidr"></param>
         /// <returns></returns>
         public static IPNetwork Parse(IPAddress ipaddress, byte cidr) {
-
             IPNetwork ipnetwork = null;
             IPNetwork.InternalParse(false, ipaddress, cidr, out ipnetwork);
             return ipnetwork;
-
         }
 
         /// <summary>
@@ -650,7 +648,6 @@ namespace System.Net
         /// <param name="cidr"></param>
         /// <returns></returns>
         private static void InternalParse(bool tryParse, IPAddress ipaddress, byte cidr, out IPNetwork ipnetwork) {
-
             if (ipaddress == null)
             {
                 if (tryParse == false)

--- a/src/TestProject/IPNetworkUnitTest.cs
+++ b/src/TestProject/IPNetworkUnitTest.cs
@@ -937,7 +937,7 @@ namespace System.Net.TestProject
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void CtorWithIpAndCidr3()
         {
             string ipaddress = "192.168.168.100";

--- a/src/TestProject/IPNetworkUnitTest.cs
+++ b/src/TestProject/IPNetworkUnitTest.cs
@@ -39,7 +39,7 @@ namespace System.Net.TestProject
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void TestParseIPAddressNetmaskANE4() {
-            IPNetwork.Parse(null, 0);
+            IPNetwork.Parse((string)null, 0);
         }
 
         [TestMethod]

--- a/src/TestProject/IPNetworkUnitTest.cs
+++ b/src/TestProject/IPNetworkUnitTest.cs
@@ -917,29 +917,32 @@ namespace System.Net.TestProject
 
         #endregion
 
-        #region ParseIpCidr
+        #region CtorWithIpAndCidr
 
         [TestMethod]
-        public void ParseIpCidr1() {
+        public void CtorWithIpAndCidr1()
+        {
             string ipaddress = "192.168.168.100";
             IPAddress ip = IPAddress.Parse(ipaddress);
-            IPNetwork ipnetwork = IPNetwork.Parse(ip, 24);
+            IPNetwork ipnetwork = new IPNetwork(ip, 24);
             Assert.AreEqual("192.168.168.0/24", ipnetwork.ToString(), "network");
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
-        public void ParseIpCidr2() {
+        public void CtorWithIpAndCidr2()
+        {
             IPAddress ip = null;
-            IPNetwork ipnetwork = IPNetwork.Parse(ip, 24);
+            IPNetwork ipnetwork = new IPNetwork(ip, 24);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void ParseIpCidr3() {
+        public void CtorWithIpAndCidr3()
+        {
             string ipaddress = "192.168.168.100";
             IPAddress ip = IPAddress.Parse(ipaddress);
-            IPNetwork ipnetwork = IPNetwork.Parse(ip, 33);
+            IPNetwork ipnetwork = new IPNetwork(ip, 33);
         }
 
         #endregion

--- a/src/TestProject/IPNetworkUnitTest.cs
+++ b/src/TestProject/IPNetworkUnitTest.cs
@@ -935,7 +935,7 @@ namespace System.Net.TestProject
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [ExpectedException(typeof(ArgumentException))]
         public void ParseIpCidr3() {
             string ipaddress = "192.168.168.100";
             IPAddress ip = IPAddress.Parse(ipaddress);

--- a/src/TestProject/IPNetworkUnitTest.cs
+++ b/src/TestProject/IPNetworkUnitTest.cs
@@ -921,31 +921,25 @@ namespace System.Net.TestProject
 
         [TestMethod]
         public void ParseIpCidr1() {
-
             string ipaddress = "192.168.168.100";
             IPAddress ip = IPAddress.Parse(ipaddress);
             IPNetwork ipnetwork = IPNetwork.Parse(ip, 24);
             Assert.AreEqual("192.168.168.0/24", ipnetwork.ToString(), "network");
-
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ParseIpCidr2() {
-
             IPAddress ip = null;
             IPNetwork ipnetwork = IPNetwork.Parse(ip, 24);
-
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ParseIpCidr3() {
-
             string ipaddress = "192.168.168.100";
             IPAddress ip = IPAddress.Parse(ipaddress);
             IPNetwork ipnetwork = IPNetwork.Parse(ip, 33);
-
         }
 
         #endregion

--- a/src/TestProject/IPNetworkUnitTest.cs
+++ b/src/TestProject/IPNetworkUnitTest.cs
@@ -917,6 +917,39 @@ namespace System.Net.TestProject
 
         #endregion
 
+        #region ParseIpCidr
+
+        [TestMethod]
+        public void ParseIpCidr1() {
+
+            string ipaddress = "192.168.168.100";
+            IPAddress ip = IPAddress.Parse(ipaddress);
+            IPNetwork ipnetwork = IPNetwork.Parse(ip, 24);
+            Assert.AreEqual("192.168.168.0/24", ipnetwork.ToString(), "network");
+
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ParseIpCidr2() {
+
+            IPAddress ip = null;
+            IPNetwork ipnetwork = IPNetwork.Parse(ip, 24);
+
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ParseIpCidr3() {
+
+            string ipaddress = "192.168.168.100";
+            IPAddress ip = IPAddress.Parse(ipaddress);
+            IPNetwork ipnetwork = IPNetwork.Parse(ip, 33);
+
+        }
+
+        #endregion
+
         #region ToCidr
 
         [TestMethod]

--- a/src/TestProject/IPNetworkV6UnitTest.cs
+++ b/src/TestProject/IPNetworkV6UnitTest.cs
@@ -882,23 +882,24 @@ namespace System.Net.TestProject
 
         #endregion
 
-        #region ParseIpCidr
+        #region CtorWithIpAndCidr
 
         [TestMethod]
-        public void ParseIpCidr1() {
+        public void CtorWithIpAndCidr1()
+        {
             string ipaddress = "2001:0db8::";
             IPAddress ip = IPAddress.Parse(ipaddress);
-            IPNetwork ipnetwork = IPNetwork.Parse(ip, 124);
+            IPNetwork ipnetwork = new IPNetwork(ip, 124);
             Assert.AreEqual("2001:db8::/124", ipnetwork.ToString(), "network");
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void ParseIpCidr2()
+        public void CtorWithIpAndCidr2()
         {
             string ipaddress = "2001:db8::";
             IPAddress ip = IPAddress.Parse(ipaddress);
-            IPNetwork ipnet = IPNetwork.Parse(ipaddress, 129);
+            IPNetwork ipnetwork = new IPNetwork(ip, 129);
         }
         #endregion
 

--- a/src/TestProject/IPNetworkV6UnitTest.cs
+++ b/src/TestProject/IPNetworkV6UnitTest.cs
@@ -881,7 +881,29 @@ namespace System.Net.TestProject
         }
 
         #endregion
-        
+
+        #region ParseIpCidr
+
+        [TestMethod]
+        public void ParseIpCidr1() {
+
+            string ipaddress = "2001:0db8::";
+            IPAddress ip = IPAddress.Parse(ipaddress);
+            IPNetwork ipnetwork = IPNetwork.Parse(ip, 124);
+            Assert.AreEqual("2001:db8::/124", ipnetwork.ToString(), "network");
+
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void ParseIpCidr2()
+        {
+            string ipaddress = "2001:db8::";
+            IPAddress ip = IPAddress.Parse(ipaddress);
+            IPNetwork ipnet = IPNetwork.Parse(ipaddress, 129);
+        }
+        #endregion
+
         #region ToCidr
 
         [TestMethod]

--- a/src/TestProject/IPNetworkV6UnitTest.cs
+++ b/src/TestProject/IPNetworkV6UnitTest.cs
@@ -894,7 +894,7 @@ namespace System.Net.TestProject
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void CtorWithIpAndCidr2()
         {
             string ipaddress = "2001:db8::";

--- a/src/TestProject/IPNetworkV6UnitTest.cs
+++ b/src/TestProject/IPNetworkV6UnitTest.cs
@@ -886,12 +886,10 @@ namespace System.Net.TestProject
 
         [TestMethod]
         public void ParseIpCidr1() {
-
             string ipaddress = "2001:0db8::";
             IPAddress ip = IPAddress.Parse(ipaddress);
             IPNetwork ipnetwork = IPNetwork.Parse(ip, 124);
             Assert.AreEqual("2001:db8::/124", ipnetwork.ToString(), "network");
-
         }
 
         [TestMethod]


### PR DESCRIPTION
Hi,
thank you for merging my previous PR. After using the latest nuget I've realized that the PR doesn't make too much sense.
Rather than calling a Parse method that takes a IPAddress and a cidr I think it would make more sense to just add a public ctor instead. Since we are not parsing anything in this case to begin with, why call a Parse method?
What do you think?
Feel free to merge or ignore it.