### PR TITLE
Adds IPAddress.AsIPNetwork as an extension function. *Fixes issue #70)

### DIFF
--- a/src/System.Net.IPNetwork/IPAddressExtensions.cs
+++ b/src/System.Net.IPNetwork/IPAddressExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Net
+{
+    /// <summary>
+    /// A collection of extension functions applied to an IPAddress value.
+    /// </summary>
+    public static class IPAddressExtensions
+    {
+        /// <summary>
+        /// Convert an IPAddress value into a single-address IPNetwork for that address.
+        /// </summary>
+        /// <param name="addr">IPAddress to convert.</param>
+        /// <returns>IPNetwork object covering that IPAddress only.</returns>
+        public static IPNetwork AsIPNetwork(this IPAddress addr)
+        {
+            /* IPv4? */
+            if (addr.AddressFamily == Sockets.AddressFamily.InterNetwork)
+            {
+                /* Return address as a /32 network, the size of an IPv4 address. */
+                return new IPNetwork(addr, 32);
+            }
+
+            /* IPV6? */
+            if (addr.AddressFamily == Sockets.AddressFamily.InterNetworkV6)
+            {
+                /* Return address as a /128 network, the size of an IPv6 address. */
+                return new IPNetwork(addr, 128);
+            }
+
+            /* No other families are supported. */
+            throw new ArgumentException(
+                $"AsIPNetwork does not support addresses in the {addr.AddressFamily} family.");
+        }
+    }
+}

--- a/src/TestProject/IPAddressExtensionTests.cs
+++ b/src/TestProject/IPAddressExtensionTests.cs
@@ -1,0 +1,128 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace System.Net.TestProject
+{
+    /// <summary>
+    /// A collection of unit tests exercising the IPAddressExtensions class.
+    /// </summary>
+    [TestClass]
+    public class IPAddressExtensionTests
+    {
+        /// <summary>
+        /// Test converting a variety of IPv4 addreses into single-address networks.
+        /// </summary>
+        [TestMethod]
+        public void IPAddressToIPNetwork_SingleAddress_IPv4()
+            => IPAddressToIPNetwork_SingleAddress_Internal(
+                4,
+                "0.0.0.0",
+                "0.0.0.1",
+                "0.255.255.254",
+                "0.255.255.255",
+                "1.0.0.0",
+                "1.1.1.1",
+                "123.45.67.89",
+                "126.255.255.254",
+                "126.255.255.255",
+                "127.0.0.0",
+                "127.0.0.1",
+                "127.255.255.254",
+                "127.255.255.255",
+                "192.168.0.0",
+                "192.168.0.1",
+                "192.168.0.254",
+                "192.168.0.255",
+                "192.168.255.255",
+                "239.255.255.255",
+                "240.0.0.0",
+                "255.255.255.255");
+
+        /// <summary>
+        /// Test converting a variety of IPv6 addreses into single-address networks.
+        /// </summary>
+        [TestMethod]
+        public void IPAddressToIPNetwork_SingleAddress_IPv6()
+            => IPAddressToIPNetwork_SingleAddress_Internal(
+                16,
+                "::1",
+                "::",
+                "::1234:ABCD",
+                "1234::ABCD",
+                "1234:ABCD::",
+                "1:2:3:4:5:6:7:8",
+                "FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF");
+
+        /// <summary>
+        /// Shared test case, called upon by the above two test cases.
+        /// </summary>
+        /// <param name="byteCount">Number of bytes in the type of address being tester.</param>
+        /// <param name="interestingAddrs">A collection of interesting IP addresses to include in the test.</param>
+        private static void IPAddressToIPNetwork_SingleAddress_Internal(
+            int byteCount,
+            params string[] interestingAddrs)
+        {
+            /* Start the collection of test cases with the
+             * interesting addresses from the caller. */
+            var addrs = interestingAddrs.ToList();
+
+            /* Populate with random but deterministic addresses. */
+            addrs.AddRange(RandomIPs(byteCount));
+
+            /* Loop through all of the test cases. */
+            foreach (var ipAddr in addrs.Select(IPAddress.Parse))
+            {
+                /* Convert to network, then pass the network object to a checker. */
+                TestForSingleAddressNetwork(
+                    ipAddr,
+                    ipAddr.AsIPNetwork(),
+                    byteCount * 8);
+            }
+        }
+
+        /// <summary>
+        /// Generate random but deterministic IPs.
+        /// </summary>
+        /// <param name="byteCount">4 for IPv4. 16 for IPv6.</param>
+        /// <returns>Collection of random IP addresses.</returns>
+        private static IEnumerable<string> RandomIPs(int byteCount)
+        {
+            /* Start from a fixed starting byte array.
+             * Using a GUID's bytes so the sequence will be unique, with the first
+             * byte XOR'd with the byte count so the two sequences will be different. */
+            byte[] hashInput = Guid.Parse("12f2c3ba-7bd1-4ec3-922c-a5625b8f5dd5").ToByteArray();
+            hashInput[0] ^= (byte)byteCount;
+
+            /* Loop many times. */
+            foreach (int i in Enumerable.Range(1, 1000))
+            {
+                /* Hash the current interation to get a new block of deterministic bytes. */
+                using (var hash = System.Security.Cryptography.SHA256.Create())
+                {
+                    hashInput = hash.ComputeHash(hashInput);
+                }
+
+                /* Convert the first n bytes for an address. 4 will have an IPv4. 16 will make an IPv6. */
+                yield return new IPAddress(hashInput.Take(byteCount).ToArray()).ToString();
+            }
+        }
+
+        /// <summary>
+        /// Test if a single address network is valid.
+        /// </summary>
+        /// <param name="ipAddr">Expected addresss.</param>
+        /// <param name="net">Actual network.</param>
+        /// <param name="expectedSize">Expected CIDRsize. (32 or 128.)</param>
+        private static void TestForSingleAddressNetwork(IPAddress ipAddr, IPNetwork net, int expectedSize)
+        {
+            Assert.AreEqual($"{ipAddr}/{expectedSize}", $"{net}");
+            Assert.AreEqual(ipAddr, net.FirstUsable);
+            Assert.AreEqual(ipAddr, net.LastUsable);
+            Assert.AreEqual(1, net.Total);
+            Assert.AreEqual(expectedSize, net.Cidr);
+        }
+    }
+}


### PR DESCRIPTION
- Adds extension function for IPAddress, converting that address into an IPNetwork object that has this address only as a member.
- Useful for loading configuration strings where a range is expected, but the user types in a single IP.
- Works with both IPv4 and IPv6.
- Unit tests exercising both types with "interesting" addresses along with a thousand randomly (yet deterministically) generated addresses of each type.
- Fixes issue #70.