### PR TITLE
[WIP] Move library to namespace IPNetwork2, add .net 8 support

### DIFF
--- a/src/ConsoleApplication/ActionEnum.cs
+++ b/src/ConsoleApplication/ActionEnum.cs
@@ -2,7 +2,7 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
-namespace System.Net.ConsoleApplication
+namespace IPNetwork2.ConsoleApplication
 {
     public enum ActionEnum
     {

--- a/src/ConsoleApplication/ArgParsed.cs
+++ b/src/ConsoleApplication/ArgParsed.cs
@@ -2,7 +2,7 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
-namespace System.Net.ConsoleApplication
+namespace IPNetwork2.ConsoleApplication
 {
     public class ArgParsed
     {

--- a/src/ConsoleApplication/CidrParseTypeEnum.cs
+++ b/src/ConsoleApplication/CidrParseTypeEnum.cs
@@ -2,7 +2,7 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
-namespace System.Net.ConsoleApplication
+namespace IPNetwork2.ConsoleApplication
 {
     public enum CidrParseEnum
     {

--- a/src/ConsoleApplication/ConsoleApplication.csproj
+++ b/src/ConsoleApplication/ConsoleApplication.csproj
@@ -2,34 +2,32 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net462;net47;net48;netcoreapp3.1;net6.0</TargetFrameworks>
-		<TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0</TargetFrameworks>
+		<TargetFrameworks>net462;net47;net48;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net8.0</TargetFrameworks>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>..\System.Net.IPNetwork.snk</AssemblyOriginatorKeyFile>
-
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <None Remove="stylecop.json" />
+		<None Remove="stylecop.json" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <AdditionalFiles Include="stylecop.json" />
+		<AdditionalFiles Include="stylecop.json" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="GnuGetOpt" Version="0.9.2.6" />
-	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
+		<PackageReference Include="GnuGetOpt" Version="0.9.2.6" />
+		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
-	
 	<ItemGroup>
 		<!-- ProjectReference Include="..\Gnu.Getopt\Gnu.Getopt.csproj" /-->
-    <ProjectReference Include="..\System.Net.IPNetwork\System.Net.IPNetwork.csproj" />
-  </ItemGroup>
+		<ProjectReference Include="..\System.Net.IPNetwork\System.Net.IPNetwork.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/ConsoleApplication/Program.cs
+++ b/src/ConsoleApplication/Program.cs
@@ -2,15 +2,18 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Numerics;
+using System.Reflection;
+
+using Gnu.Getopt;
+
+using IPNetwork2;
+
 namespace System.Net.ConsoleApplication
 {
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.IO;
-    using System.Numerics;
-    using System.Reflection;
-    using Gnu.Getopt;
-
     /// <summary>
     /// Console app for IPNetwork.
     /// </summary>
@@ -61,7 +64,7 @@ namespace System.Net.ConsoleApplication
             }),
             new ArgParsed('C', (ac, arg) =>
             {
-                if (!Program.TryParseIPNetwork(arg, ac.CidrParse, ac.CidrParsed, out IPNetwork ipnetwork))
+                if (!TryParseIPNetwork(arg, ac.CidrParse, ac.CidrParsed, out IPNetwork ipnetwork))
                 {
                     Console.WriteLine("Unable to parse ipnetwork {0}", arg);
                     ac.Action = ActionEnum.Usage;
@@ -73,7 +76,7 @@ namespace System.Net.ConsoleApplication
             }),
             new ArgParsed('o', (ac, arg) =>
             {
-                if (!Program.TryParseIPNetwork(arg, ac.CidrParse, ac.CidrParsed, out IPNetwork ipnetwork))
+                if (!TryParseIPNetwork(arg, ac.CidrParse, ac.CidrParsed, out IPNetwork ipnetwork))
                 {
                     Console.WriteLine("Unable to parse ipnetwork {0}", arg);
                     ac.Action = ActionEnum.Usage;
@@ -85,7 +88,7 @@ namespace System.Net.ConsoleApplication
             }),
             new ArgParsed('S', (ac, arg) =>
             {
-                if (!Program.TryParseIPNetwork(arg, ac.CidrParse, ac.CidrParsed, out IPNetwork ipnetwork))
+                if (!TryParseIPNetwork(arg, ac.CidrParse, ac.CidrParsed, out IPNetwork ipnetwork))
                 {
                     Console.WriteLine("Unable to parse ipnetwork {0}", arg);
                     ac.Action = ActionEnum.Usage;
@@ -103,35 +106,35 @@ namespace System.Net.ConsoleApplication
         /// <param name="args">program arguments.</param>
         public static void Main(string[] args)
         {
-            ProgramContext ac = Program.ParseArgs(args);
+            ProgramContext ac = ParseArgs(args);
 
             if (ac.Action == ActionEnum.Subnet)
             {
-                Program.SubnetNetworks(ac);
+                SubnetNetworks(ac);
             }
             else if (ac.Action == ActionEnum.Supernet)
             {
-                Program.SupernetNetworks(ac);
+                SupernetNetworks(ac);
             }
             else if (ac.Action == ActionEnum.WideSupernet)
             {
-                Program.WideSupernetNetworks(ac);
+                WideSupernetNetworks(ac);
             }
             else if (ac.Action == ActionEnum.PrintNetworks)
             {
-                Program.PrintNetworks(ac);
+                PrintNetworks(ac);
             }
             else if (ac.Action == ActionEnum.ContainNetwork)
             {
-                Program.ContainNetwork(ac);
+                ContainNetwork(ac);
             }
             else if (ac.Action == ActionEnum.OverlapNetwork)
             {
-                Program.OverlapNetwork(ac);
+                OverlapNetwork(ac);
             }
             else if (ac.Action == ActionEnum.ListIPAddress)
             {
-                Program.ListIPAddress(ac);
+                ListIPAddress(ac);
                 /**
                  * Need a better way to do it
                  *
@@ -142,7 +145,7 @@ namespace System.Net.ConsoleApplication
             }
             else
             {
-                Program.Usage();
+                Usage();
             }
         }
 
@@ -182,7 +185,7 @@ namespace System.Net.ConsoleApplication
                 Console.WriteLine("Unable to wide subnet these networks");
             }
 
-            Program.PrintNetwork(ac, widesubnet);
+            PrintNetwork(ac, widesubnet);
         }
 
         private static void SupernetNetworks(ProgramContext ac)
@@ -192,7 +195,7 @@ namespace System.Net.ConsoleApplication
                 Console.WriteLine("Unable to supernet these networks");
             }
 
-            Program.PrintNetworks(ac, supernet, supernet.Length);
+            PrintNetworks(ac, supernet, supernet.Length);
         }
 
         private static void PrintNetworks(ProgramContext ac, IEnumerable<IPNetwork> ipnetworks, BigInteger networkLength)
@@ -201,8 +204,8 @@ namespace System.Net.ConsoleApplication
             foreach (IPNetwork ipn in ipnetworks)
             {
                 i++;
-                Program.PrintNetwork(ac, ipn);
-                Program.PrintSeparator(networkLength, i);
+                PrintNetwork(ac, ipn);
+                PrintSeparator(networkLength, i);
             }
         }
 
@@ -216,12 +219,12 @@ namespace System.Net.ConsoleApplication
                 if (!ipnetwork.TrySubnet(ac.SubnetCidr, out IPNetworkCollection ipnetworks))
                 {
                     Console.WriteLine("Unable to subnet ipnetwork {0} into cidr {1}", ipnetwork, ac.SubnetCidr);
-                    Program.PrintSeparator(networkLength, i);
+                    PrintSeparator(networkLength, i);
                     continue;
                 }
 
                 Program.PrintNetworks(ac, ipnetworks, ipnetworks.Count);
-                Program.PrintSeparator(networkLength, i);
+                PrintSeparator(networkLength, i);
             }
         }
 
@@ -244,8 +247,8 @@ namespace System.Net.ConsoleApplication
             foreach (IPNetwork ipnetwork in ac.Networks)
             {
                 i++;
-                Program.PrintNetwork(ac, ipnetwork);
-                Program.PrintSeparator(ac.Networks.Length, i);
+                PrintNetwork(ac, ipnetwork);
+                PrintSeparator(ac.Networks.Length, i);
             }
         }
 
@@ -304,9 +307,9 @@ namespace System.Net.ConsoleApplication
 
         static Program()
         {
-            foreach (ArgParsed ap in Program.ArgsList)
+            foreach (ArgParsed ap in ArgsList)
             {
-                Program.Args.Add(ap.Arg, ap);
+                Args.Add(ap.Arg, ap);
             }
         }
 
@@ -319,7 +322,7 @@ namespace System.Net.ConsoleApplication
             while ((c = g.getopt()) != -1)
             {
                 string optArg = g.Optarg;
-                Program.Args[c].Run(ac, optArg);
+                Args[c].Run(ac, optArg);
             }
 
             var ipnetworks = new List<string>();
@@ -332,7 +335,7 @@ namespace System.Net.ConsoleApplication
             }
 
             ac.NetworksString = ipnetworks.ToArray();
-            Program.ParseIPNetworks(ac);
+            ParseIPNetworks(ac);
 
             if (ac.Networks.Length == 0)
             {
@@ -354,14 +357,14 @@ namespace System.Net.ConsoleApplication
                 ac.Action = ActionEnum.Usage;
             }
 
-            if (Program.PrintNoValue(ac))
+            if (PrintNoValue(ac))
             {
-                Program.PrintAll(ac);
+                PrintAll(ac);
             }
 
             if (g.Optind == 0)
             {
-                Program.PrintAll(ac);
+                PrintAll(ac);
             }
 
             return ac;
@@ -372,7 +375,7 @@ namespace System.Net.ConsoleApplication
             var ipnetworks = new List<IPNetwork>();
             foreach (string ips in ac.NetworksString)
             {
-                if (!Program.TryParseIPNetwork(ips, ac.CidrParse, ac.CidrParsed, out IPNetwork ipnetwork))
+                if (!TryParseIPNetwork(ips, ac.CidrParse, ac.CidrParsed, out IPNetwork ipnetwork))
                 {
                     Console.WriteLine("Unable to parse ipnetwork {0}", ips);
                     continue;

--- a/src/ConsoleApplication/Program.cs
+++ b/src/ConsoleApplication/Program.cs
@@ -2,17 +2,18 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
+using System.Net.Sockets;
 using System.Numerics;
 using System.Reflection;
 
 using Gnu.Getopt;
 
-using IPNetwork2;
-
-namespace System.Net.ConsoleApplication
+namespace IPNetwork2.ConsoleApplication
 {
     /// <summary>
     /// Console app for IPNetwork.
@@ -40,7 +41,7 @@ namespace System.Net.ConsoleApplication
             new ArgParsed('D', (ac, arg) => { ac.CidrParse = CidrParseEnum.Default; }),
             new ArgParsed('d', (ac, arg) =>
             {
-                if (!IPNetwork.TryParseCidr(arg, Sockets.AddressFamily.InterNetwork, out byte? cidr))
+                if (!IPNetwork.TryParseCidr(arg, AddressFamily.InterNetwork, out byte? cidr))
                 {
                     Console.WriteLine("Invalid cidr {0}", cidr);
                     ac.Action = ActionEnum.Usage;
@@ -52,7 +53,7 @@ namespace System.Net.ConsoleApplication
             }),
             new ArgParsed('s', (ac, arg) =>
             {
-                if (!IPNetwork.TryParseCidr(arg, Sockets.AddressFamily.InterNetwork, out byte? cidr))
+                if (!IPNetwork.TryParseCidr(arg, AddressFamily.InterNetwork, out byte? cidr))
                 {
                     Console.WriteLine("Invalid cidr {0}", cidr);
                     ac.Action = ActionEnum.Usage;

--- a/src/ConsoleApplication/ProgramContext.cs
+++ b/src/ConsoleApplication/ProgramContext.cs
@@ -2,6 +2,8 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using IPNetwork2;
+
 namespace System.Net.ConsoleApplication
 {
     public class ProgramContext

--- a/src/ConsoleApplication/ProgramContext.cs
+++ b/src/ConsoleApplication/ProgramContext.cs
@@ -4,7 +4,7 @@
 
 using IPNetwork2;
 
-namespace System.Net.ConsoleApplication
+namespace IPNetwork2.ConsoleApplication
 {
     public class ProgramContext
     {

--- a/src/ConsoleApplication/stylecop.json
+++ b/src/ConsoleApplication/stylecop.json
@@ -4,8 +4,6 @@
     "documentationRules": {
       "companyName": "IPNetwork",
       "copyrightText": "Copyright (c) {companyName}. All rights reserved."
-
-
     }
   }
 }

--- a/src/System.Net.IPNetwork/BigIntegerExtensions.cs
+++ b/src/System.Net.IPNetwork/BigIntegerExtensions.cs
@@ -2,12 +2,12 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
-namespace System.Net
-{
-    using System;
-    using System.Numerics;
-    using System.Text;
+using System;
+using System.Numerics;
+using System.Text;
 
+namespace IPNetwork2
+{
     /// <summary>
     /// Extension methods to convert <see cref="System.Numerics.BigInteger"/>
     /// instances to hexadecimal, octal, and binary strings.

--- a/src/System.Net.IPNetwork/CidrClassFull.cs
+++ b/src/System.Net.IPNetwork/CidrClassFull.cs
@@ -2,10 +2,11 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
-namespace System.Net
-{
-    using System.Net.Sockets;
+using System.Net;
+using System.Net.Sockets;
 
+namespace IPNetwork2
+{
     /// <summary>
     /// Class <c>CidrClassFull</c> tries to guess CIDR in a ClassFull way.
     /// </summary>

--- a/src/System.Net.IPNetwork/CidrClassLess.cs
+++ b/src/System.Net.IPNetwork/CidrClassLess.cs
@@ -2,10 +2,11 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
-namespace System.Net
-{
-    using System.Net.Sockets;
+using System.Net;
+using System.Net.Sockets;
 
+namespace IPNetwork2
+{
     /// <summary>
     /// Try to guess a CIDR in a ClassLess way ie. ipv4 = 32, ipv6 = 128.
     /// </summary>

--- a/src/System.Net.IPNetwork/CidrGuess.cs
+++ b/src/System.Net.IPNetwork/CidrGuess.cs
@@ -2,7 +2,9 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
-namespace System.Net
+using System;
+
+namespace IPNetwork2
 {
     /// <summary>
     /// A static helper CidrGuess class.

--- a/src/System.Net.IPNetwork/ICidrGuess.cs
+++ b/src/System.Net.IPNetwork/ICidrGuess.cs
@@ -2,7 +2,7 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
-namespace System.Net
+namespace IPNetwork2
 {
     /// <summary>
     ///

--- a/src/System.Net.IPNetwork/IPAddressCollection.cs
+++ b/src/System.Net.IPNetwork/IPAddressCollection.cs
@@ -2,12 +2,15 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
-namespace System.Net
-{
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Numerics;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Numerics;
 
+namespace IPNetwork2
+{
     public enum FilterEnum
     {
         All,
@@ -59,7 +62,7 @@ namespace System.Net
                     throw new ArgumentOutOfRangeException("i");
                 }
 
-                byte width = this._ipnetwork.AddressFamily == Sockets.AddressFamily.InterNetwork ? (byte)32 : (byte)128;
+                byte width = this._ipnetwork.AddressFamily == AddressFamily.InterNetwork ? (byte)32 : (byte)128;
                 IPNetworkCollection ipn = this._ipnetwork.Subnet(width);
 
                 BigInteger index = i;

--- a/src/System.Net.IPNetwork/IPAddressExtensions.cs
+++ b/src/System.Net.IPNetwork/IPAddressExtensions.cs
@@ -2,7 +2,11 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
-namespace System.Net
+using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace IPNetwork2
 {
     /// <summary>
     /// A collection of extension functions applied to an IPAddress value.
@@ -17,14 +21,14 @@ namespace System.Net
         public static IPNetwork AsIPNetwork(this IPAddress addr)
         {
             /* IPv4? */
-            if (addr.AddressFamily == Sockets.AddressFamily.InterNetwork)
+            if (addr.AddressFamily == AddressFamily.InterNetwork)
             {
                 /* Return address as a /32 network, the size of an IPv4 address. */
                 return new IPNetwork(addr, 32);
             }
 
             /* IPV6? */
-            if (addr.AddressFamily == Sockets.AddressFamily.InterNetworkV6)
+            if (addr.AddressFamily == AddressFamily.InterNetworkV6)
             {
                 /* Return address as a /128 network, the size of an IPv6 address. */
                 return new IPNetwork(addr, 128);

--- a/src/System.Net.IPNetwork/IPNetwork.cs
+++ b/src/System.Net.IPNetwork/IPNetwork.cs
@@ -2,16 +2,17 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
-namespace System.Net
-{
-    using System.Collections.Generic;
-    using System.ComponentModel;
-    using System.IO;
-    using System.Net.Sockets;
-    using System.Numerics;
-    using System.Runtime.Serialization;
-    using System.Text.RegularExpressions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Numerics;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
 
+namespace IPNetwork2
+{
     /// <summary>
     /// IP Network utility class.
     /// Use IPNetwork.Parse to create instances.
@@ -39,7 +40,7 @@ namespace System.Net
 
             set
             {
-                var ipnetwork = IPNetwork.Parse(value);
+                var ipnetwork = Parse(value);
                 this._ipaddress = ipnetwork._ipaddress;
                 this._family = ipnetwork._family;
                 this._cidr = ipnetwork._cidr;
@@ -70,7 +71,7 @@ namespace System.Net
         {
             get
             {
-                return IPNetwork.ToIPAddress(this._network, this._family);
+                return ToIPAddress(this._network, this._family);
             }
         }
 
@@ -89,7 +90,7 @@ namespace System.Net
         {
             get
             {
-                return IPNetwork.ToUint(this._cidr, this._family);
+                return ToUint(this._cidr, this._family);
             }
         }
 
@@ -100,7 +101,7 @@ namespace System.Net
         {
             get
             {
-                return IPNetwork.ToIPAddress(this._netmask, this._family);
+                return ToIPAddress(this._netmask, this._family);
             }
         }
 
@@ -137,12 +138,12 @@ namespace System.Net
         {
             get
             {
-                if (this._family == Sockets.AddressFamily.InterNetworkV6)
+                if (this._family == AddressFamily.InterNetworkV6)
                 {
                     return null;
                 }
 
-                return IPNetwork.ToIPAddress(this._broadcast, this._family);
+                return ToIPAddress(this._broadcast, this._family);
             }
         }
 
@@ -153,10 +154,10 @@ namespace System.Net
         {
             get
             {
-                BigInteger fisrt = this._family == Sockets.AddressFamily.InterNetworkV6
+                BigInteger fisrt = this._family == AddressFamily.InterNetworkV6
                     ? this._network
                     : (this.Usable <= 0) ? this._network : this._network + 1;
-                return IPNetwork.ToIPAddress(fisrt, this._family);
+                return ToIPAddress(fisrt, this._family);
             }
         }
 
@@ -167,10 +168,10 @@ namespace System.Net
         {
             get
             {
-                BigInteger last = this._family == Sockets.AddressFamily.InterNetworkV6
+                BigInteger last = this._family == AddressFamily.InterNetworkV6
                     ? this._broadcast
                     : (this.Usable <= 0) ? this._network : this._broadcast - 1;
-                return IPNetwork.ToIPAddress(last, this._family);
+                return ToIPAddress(last, this._family);
             }
         }
 
@@ -181,7 +182,7 @@ namespace System.Net
         {
             get
             {
-                if (this._family == Sockets.AddressFamily.InterNetworkV6)
+                if (this._family == AddressFamily.InterNetworkV6)
                 {
                     return this.Total;
                 }
@@ -200,7 +201,7 @@ namespace System.Net
         {
             get
             {
-                int max = this._family == Sockets.AddressFamily.InterNetwork ? 32 : 128;
+                int max = this._family == AddressFamily.InterNetwork ? 32 : 128;
                 var count = BigInteger.Pow(2, max - this._cidr);
                 return count;
             }
@@ -287,7 +288,7 @@ namespace System.Net
         /// <returns>An IPNetwork equivalent to the network contained in ipaddress/netmask.</returns>
         public static IPNetwork Parse(string ipaddress, string netmask)
         {
-            IPNetwork.InternalParse(false, ipaddress, netmask, out IPNetwork ipnetwork);
+            InternalParse(false, ipaddress, netmask, out IPNetwork ipnetwork);
             return ipnetwork;
         }
 
@@ -306,7 +307,7 @@ namespace System.Net
         /// <returns>An IPNetwork equivalent to the network contained in ipaddress/cidr.</returns>
         public static IPNetwork Parse(string ipaddress, byte cidr)
         {
-            IPNetwork.InternalParse(false, ipaddress, cidr, out IPNetwork ipnetwork);
+            InternalParse(false, ipaddress, cidr, out IPNetwork ipnetwork);
             return ipnetwork;
         }
 
@@ -325,7 +326,7 @@ namespace System.Net
         /// <returns>An IPNetwork equivalent to the network contained in ipaddress/netmask.</returns>
         public static IPNetwork Parse(IPAddress ipaddress, IPAddress netmask)
         {
-            IPNetwork.InternalParse(false, ipaddress, netmask, out IPNetwork ipnetwork);
+            InternalParse(false, ipaddress, netmask, out IPNetwork ipnetwork);
             return ipnetwork;
         }
 
@@ -344,7 +345,7 @@ namespace System.Net
         /// <returns>An IPNetwork equivalent to the network contained in string network.</returns>
         public static IPNetwork Parse(string network)
         {
-            IPNetwork.InternalParse(false, network, CidrGuess.ClassFull, true, out IPNetwork ipnetwork);
+            InternalParse(false, network, CidrGuess.ClassFull, true, out IPNetwork ipnetwork);
             return ipnetwork;
         }
 
@@ -364,7 +365,7 @@ namespace System.Net
         /// <returns>An IPNetwork equivalent to the network contained in string network.</returns>
         public static IPNetwork Parse(string network, bool sanitanize)
         {
-            IPNetwork.InternalParse(false, network, CidrGuess.ClassFull, sanitanize, out IPNetwork ipnetwork);
+            InternalParse(false, network, CidrGuess.ClassFull, sanitanize, out IPNetwork ipnetwork);
             return ipnetwork;
         }
 
@@ -384,7 +385,7 @@ namespace System.Net
         /// <returns>An IPNetwork equivalent to the network contained in string network.</returns>
         public static IPNetwork Parse(string network, ICidrGuess cidrGuess)
         {
-            IPNetwork.InternalParse(false, network, cidrGuess, true, out IPNetwork ipnetwork);
+            InternalParse(false, network, cidrGuess, true, out IPNetwork ipnetwork);
             return ipnetwork;
         }
 
@@ -405,7 +406,7 @@ namespace System.Net
         /// <returns>An IPNetwork equivalent to the network contained in string network.</returns>
         public static IPNetwork Parse(string network, ICidrGuess cidrGuess, bool sanitanize)
         {
-            IPNetwork.InternalParse(false, network, cidrGuess, sanitanize, out IPNetwork ipnetwork);
+            InternalParse(false, network, cidrGuess, sanitanize, out IPNetwork ipnetwork);
             return ipnetwork;
         }
 
@@ -429,7 +430,7 @@ namespace System.Net
         /// <returns>true if ipaddress/netmask was converted successfully; otherwise, false..</returns>
         public static bool TryParse(string ipaddress, string netmask, out IPNetwork ipnetwork)
         {
-            IPNetwork.InternalParse(true, ipaddress, netmask, out IPNetwork ipnetwork2);
+            InternalParse(true, ipaddress, netmask, out IPNetwork ipnetwork2);
             bool parsed = ipnetwork2 != null;
             ipnetwork = ipnetwork2;
 
@@ -452,7 +453,7 @@ namespace System.Net
         /// <returns>true if ipaddress/cidr was converted successfully; otherwise, false..</returns>
         public static bool TryParse(string ipaddress, byte cidr, out IPNetwork ipnetwork)
         {
-            IPNetwork.InternalParse(true, ipaddress, cidr, out IPNetwork ipnetwork2);
+            InternalParse(true, ipaddress, cidr, out IPNetwork ipnetwork2);
             bool parsed = ipnetwork2 != null;
             ipnetwork = ipnetwork2;
 
@@ -476,7 +477,7 @@ namespace System.Net
         public static bool TryParse(string network, out IPNetwork ipnetwork)
         {
             bool sanitanize = true;
-            IPNetwork.InternalParse(true, network, CidrGuess.ClassFull, sanitanize, out IPNetwork ipnetwork2);
+            InternalParse(true, network, CidrGuess.ClassFull, sanitanize, out IPNetwork ipnetwork2);
             bool parsed = ipnetwork2 != null;
             ipnetwork = ipnetwork2;
 
@@ -500,7 +501,7 @@ namespace System.Net
         /// <returns>true if network was converted successfully; otherwise, false..</returns>
         public static bool TryParse(string network, bool sanitanize, out IPNetwork ipnetwork)
         {
-            IPNetwork.InternalParse(true, network, CidrGuess.ClassFull, sanitanize, out IPNetwork ipnetwork2);
+            InternalParse(true, network, CidrGuess.ClassFull, sanitanize, out IPNetwork ipnetwork2);
             bool parsed = ipnetwork2 != null;
             ipnetwork = ipnetwork2;
 
@@ -524,7 +525,7 @@ namespace System.Net
         /// <returns>true if network was converted successfully; otherwise, false..</returns>
         public static bool TryParse(IPAddress ipaddress, IPAddress netmask, out IPNetwork ipnetwork)
         {
-            IPNetwork.InternalParse(true, ipaddress, netmask, out IPNetwork ipnetwork2);
+            InternalParse(true, ipaddress, netmask, out IPNetwork ipnetwork2);
             bool parsed = ipnetwork2 != null;
             ipnetwork = ipnetwork2;
 
@@ -597,7 +598,7 @@ namespace System.Net
                 return;
             }
 
-            IPNetwork.InternalParse(tryParse, ip, mask, out ipnetwork);
+            InternalParse(tryParse, ip, mask, out ipnetwork);
         }
 
         private static void InternalParse(bool tryParse, string network, ICidrGuess cidrGuess, bool sanitanize, out IPNetwork ipnetwork)
@@ -629,7 +630,7 @@ namespace System.Net
                 string cidrlessNetwork = args[0];
                 if (cidrGuess.TryGuessCidr(cidrlessNetwork, out cidr))
                 {
-                    IPNetwork.InternalParse(tryParse, cidrlessNetwork, cidr, out ipnetwork);
+                    InternalParse(tryParse, cidrlessNetwork, cidr, out ipnetwork);
                     return;
                 }
 
@@ -644,11 +645,11 @@ namespace System.Net
 
             if (byte.TryParse(args[1], out cidr))
             {
-                IPNetwork.InternalParse(tryParse, args[0], cidr, out ipnetwork);
+                InternalParse(tryParse, args[0], cidr, out ipnetwork);
                 return;
             }
 
-            IPNetwork.InternalParse(tryParse, args[0], args[1], out ipnetwork);
+            InternalParse(tryParse, args[0], args[1], out ipnetwork);
             return;
         }
 
@@ -690,8 +691,8 @@ namespace System.Net
                 return;
             }
 
-            var uintIpAddress = IPNetwork.ToBigInteger(ipaddress);
-            bool parsed = IPNetwork.TryToCidr(netmask, out byte? cidr2);
+            var uintIpAddress = ToBigInteger(ipaddress);
+            bool parsed = TryToCidr(netmask, out byte? cidr2);
             if (parsed == false)
             {
                 if (tryParse == false)
@@ -750,7 +751,7 @@ namespace System.Net
                 return;
             }
 
-            bool parsedNetmask = IPNetwork.TryToNetmask(cidr, ip.AddressFamily, out IPAddress mask);
+            bool parsedNetmask = TryToNetmask(cidr, ip.AddressFamily, out IPAddress mask);
             if (parsedNetmask == false)
             {
                 if (tryParse == false)
@@ -762,7 +763,7 @@ namespace System.Net
                 return;
             }
 
-            IPNetwork.InternalParse(tryParse, ip, mask, out ipnetwork);
+            InternalParse(tryParse, ip, mask, out ipnetwork);
         }
         #endregion
 
@@ -779,7 +780,7 @@ namespace System.Net
         /// <returns>A number representing the ipaddress.</returns>
         public static BigInteger ToBigInteger(IPAddress ipaddress)
         {
-            IPNetwork.InternalToBigInteger(false, ipaddress, out BigInteger? uintIpAddress);
+            InternalToBigInteger(false, ipaddress, out BigInteger? uintIpAddress);
 
             return (BigInteger)uintIpAddress;
         }
@@ -794,7 +795,7 @@ namespace System.Net
         /// <returns>true if ipaddress was converted successfully; otherwise, false.</returns>
         public static bool TryToBigInteger(IPAddress ipaddress, out BigInteger? uintIpAddress)
         {
-            IPNetwork.InternalToBigInteger(true, ipaddress, out BigInteger? uintIpAddress2);
+            InternalToBigInteger(true, ipaddress, out BigInteger? uintIpAddress2);
             bool parsed = uintIpAddress2 != null;
             uintIpAddress = uintIpAddress2;
 
@@ -861,7 +862,7 @@ namespace System.Net
         /// <returns>A number representing the netmask exprimed in CIDR.</returns>
         public static BigInteger ToUint(byte cidr, AddressFamily family)
         {
-            IPNetwork.InternalToBigInteger(false, cidr, family, out BigInteger? uintNetmask);
+            InternalToBigInteger(false, cidr, family, out BigInteger? uintNetmask);
 
             return (BigInteger)uintNetmask;
         }
@@ -875,7 +876,7 @@ namespace System.Net
         /// <returns>true if cidr was converted successfully; otherwise, false.</returns>
         public static bool TryToUint(byte cidr, AddressFamily family, out BigInteger? uintNetmask)
         {
-            IPNetwork.InternalToBigInteger(true, cidr, family, out BigInteger? uintNetmask2);
+            InternalToBigInteger(true, cidr, family, out BigInteger? uintNetmask2);
             bool parsed = uintNetmask2 != null;
             uintNetmask = uintNetmask2;
 
@@ -969,7 +970,7 @@ namespace System.Net
         /// <param name="cidr">A byte representing the netmask in cidr format (/24).</param>
         private static void InternalToCidr(bool tryParse, BigInteger netmask, AddressFamily family, out byte? cidr)
         {
-            if (!IPNetwork.InternalValidNetmask(netmask, family))
+            if (!InternalValidNetmask(netmask, family))
             {
                 if (tryParse == false)
                 {
@@ -980,7 +981,7 @@ namespace System.Net
                 return;
             }
 
-            byte cidr2 = IPNetwork.BitsSet(netmask, family);
+            byte cidr2 = BitsSet(netmask, family);
             cidr = cidr2;
 
             return;
@@ -996,7 +997,7 @@ namespace System.Net
         /// <returns>A byte representing the CIDR converted from the netmask.</returns>
         public static byte ToCidr(IPAddress netmask)
         {
-            IPNetwork.InternalToCidr(false, netmask, out byte? cidr);
+            InternalToCidr(false, netmask, out byte? cidr);
             return (byte)cidr;
         }
 
@@ -1011,7 +1012,7 @@ namespace System.Net
         /// <returns>true if netmask was converted successfully; otherwise, false.</returns>
         public static bool TryToCidr(IPAddress netmask, out byte? cidr)
         {
-            IPNetwork.InternalToCidr(true, netmask, out byte? cidr2);
+            InternalToCidr(true, netmask, out byte? cidr2);
             bool parsed = cidr2 != null;
             cidr = cidr2;
             return parsed;
@@ -1030,7 +1031,7 @@ namespace System.Net
                 return;
             }
 
-            bool parsed = IPNetwork.TryToBigInteger(netmask, out BigInteger? uintNetmask2);
+            bool parsed = TryToBigInteger(netmask, out BigInteger? uintNetmask2);
 
             // 20180217 lduchosal
             // impossible to reach code.
@@ -1043,7 +1044,7 @@ namespace System.Net
             // }
             var uintNetmask = (BigInteger)uintNetmask2;
 
-            IPNetwork.InternalToCidr(tryParse, uintNetmask, netmask.AddressFamily, out byte? cidr2);
+            InternalToCidr(tryParse, uintNetmask, netmask.AddressFamily, out byte? cidr2);
             cidr = cidr2;
 
             return;
@@ -1065,7 +1066,7 @@ namespace System.Net
         /// <returns>An IPAdress representing cidr.</returns>
         public static IPAddress ToNetmask(byte cidr, AddressFamily family)
         {
-            IPNetwork.InternalToNetmask(false, cidr, family, out IPAddress netmask);
+            InternalToNetmask(false, cidr, family, out IPAddress netmask);
 
             return netmask;
         }
@@ -1083,7 +1084,7 @@ namespace System.Net
         /// <returns>true if cidr was converted successfully; otherwise, false.</returns>
         public static bool TryToNetmask(byte cidr, AddressFamily family, out IPAddress netmask)
         {
-            IPNetwork.InternalToNetmask(true, cidr, family, out IPAddress netmask2);
+            InternalToNetmask(true, cidr, family, out IPAddress netmask2);
             bool parsed = netmask2 != null;
             netmask = netmask2;
 
@@ -1119,7 +1120,7 @@ namespace System.Net
             //     netmask = null;
             //     return;
             // }
-            int maxCidr = family == Sockets.AddressFamily.InterNetwork ? 32 : 128;
+            int maxCidr = family == AddressFamily.InterNetwork ? 32 : 128;
             if (cidr > maxCidr)
             {
                 if (tryParse == false)
@@ -1131,8 +1132,8 @@ namespace System.Net
                 return;
             }
 
-            BigInteger mask = IPNetwork.ToUint(cidr, family);
-            var netmask2 = IPNetwork.ToIPAddress(mask, family);
+            BigInteger mask = ToUint(cidr, family);
+            var netmask2 = ToIPAddress(mask, family);
             netmask = netmask2;
 
             return;
@@ -1169,8 +1170,8 @@ namespace System.Net
         /// <returns>The number of bytes set to 1.</returns>
         public static uint BitsSet(IPAddress netmask)
         {
-            var uintNetmask = IPNetwork.ToBigInteger(netmask);
-            uint bits = IPNetwork.BitsSet(uintNetmask, netmask.AddressFamily);
+            var uintNetmask = ToBigInteger(netmask);
+            uint bits = BitsSet(uintNetmask, netmask.AddressFamily);
 
             return bits;
         }
@@ -1193,8 +1194,8 @@ namespace System.Net
                 throw new ArgumentNullException("netmask");
             }
 
-            var uintNetmask = IPNetwork.ToBigInteger(netmask);
-            bool valid = IPNetwork.InternalValidNetmask(uintNetmask, netmask.AddressFamily);
+            var uintNetmask = ToBigInteger(netmask);
+            bool valid = InternalValidNetmask(uintNetmask, netmask.AddressFamily);
 
             return valid;
         }
@@ -1304,7 +1305,7 @@ namespace System.Net
 
             BigInteger uintNetwork = this._network;
             BigInteger uintBroadcast = this._broadcast; // CreateBroadcast(ref uintNetwork, this._netmask, this._family);
-            var uintAddress = IPNetwork.ToBigInteger(contains);
+            var uintAddress = ToBigInteger(contains);
 
             bool result = uintAddress >= uintNetwork
                 && uintAddress <= uintBroadcast;
@@ -1421,9 +1422,9 @@ namespace System.Net
 
         #region IANA block
 
-        private static readonly Lazy<IPNetwork> _iana_ablock_reserved = new Lazy<IPNetwork>(() => IPNetwork.Parse("10.0.0.0/8"));
-        private static readonly Lazy<IPNetwork> _iana_bblock_reserved = new Lazy<IPNetwork>(() => IPNetwork.Parse("172.16.0.0/12"));
-        private static readonly Lazy<IPNetwork> _iana_cblock_reserved = new Lazy<IPNetwork>(() => IPNetwork.Parse("192.168.0.0/16"));
+        private static readonly Lazy<IPNetwork> _iana_ablock_reserved = new Lazy<IPNetwork>(() => Parse("10.0.0.0/8"));
+        private static readonly Lazy<IPNetwork> _iana_bblock_reserved = new Lazy<IPNetwork>(() => Parse("172.16.0.0/12"));
+        private static readonly Lazy<IPNetwork> _iana_cblock_reserved = new Lazy<IPNetwork>(() => Parse("192.168.0.0/16"));
 
         /// <summary>
         /// Gets 10.0.0.0/8.
@@ -1474,9 +1475,9 @@ namespace System.Net
                 throw new ArgumentNullException("ipaddress");
             }
 
-            return IPNetwork.IANA_ABLK_RESERVED1.Contains(ipaddress)
-                || IPNetwork.IANA_BBLK_RESERVED1.Contains(ipaddress)
-                || IPNetwork.IANA_CBLK_RESERVED1.Contains(ipaddress);
+            return IANA_ABLK_RESERVED1.Contains(ipaddress)
+                || IANA_BBLK_RESERVED1.Contains(ipaddress)
+                || IANA_CBLK_RESERVED1.Contains(ipaddress);
         }
 
         /// <summary>
@@ -1486,9 +1487,9 @@ namespace System.Net
         /// <returns>true if the ipnetwork is a IANA reserverd IP Netowkr ; otherwise, false.</returns>
         public bool IsIANAReserved()
         {
-            return IPNetwork.IANA_ABLK_RESERVED1.Contains(this)
-                || IPNetwork.IANA_BBLK_RESERVED1.Contains(this)
-                || IPNetwork.IANA_CBLK_RESERVED1.Contains(this);
+            return IANA_ABLK_RESERVED1.Contains(this)
+                || IANA_BBLK_RESERVED1.Contains(this)
+                || IANA_CBLK_RESERVED1.Contains(this);
         }
 
         [Obsolete("static IsIANAReserved is deprecated, please use instance IsIANAReserved.")]
@@ -1515,7 +1516,7 @@ namespace System.Net
         /// <returns>A IPNetworkCollection splitted by CIDR.</returns>
         public IPNetworkCollection Subnet(byte cidr)
         {
-            IPNetwork.InternalSubnet(false, this, cidr, out IPNetworkCollection ipnetworkCollection);
+            InternalSubnet(false, this, cidr, out IPNetworkCollection ipnetworkCollection);
 
             return ipnetworkCollection;
         }
@@ -1541,7 +1542,7 @@ namespace System.Net
         /// <returns>true if network was split successfully; otherwise, false.</returns>
         public bool TrySubnet(byte cidr, out IPNetworkCollection ipnetworkCollection)
         {
-            IPNetwork.InternalSubnet(true, this, cidr, out IPNetworkCollection inc);
+            InternalSubnet(true, this, cidr, out IPNetworkCollection inc);
             if (inc == null)
             {
                 ipnetworkCollection = null;
@@ -1581,7 +1582,7 @@ namespace System.Net
                 return;
             }
 
-            int maxCidr = network._family == Sockets.AddressFamily.InterNetwork ? 32 : 128;
+            int maxCidr = network._family == AddressFamily.InterNetwork ? 32 : 128;
             if (cidr > maxCidr)
             {
                 if (trySubnet == false)
@@ -1622,7 +1623,7 @@ namespace System.Net
         /// <returns>A supernetted IP Network.</returns>
         public IPNetwork Supernet(IPNetwork network2)
         {
-            IPNetwork.InternalSupernet(false, this, network2, out IPNetwork supernet);
+            InternalSupernet(false, this, network2, out IPNetwork supernet);
             return supernet;
         }
 
@@ -1643,7 +1644,7 @@ namespace System.Net
         /// <returns>true if network2 was supernetted successfully; otherwise, false.</returns>
         public bool TrySupernet(IPNetwork network2, out IPNetwork supernet)
         {
-            IPNetwork.InternalSupernet(true, this, network2, out IPNetwork outSupernet);
+            InternalSupernet(true, this, network2, out IPNetwork outSupernet);
             bool parsed = outSupernet != null;
             supernet = outSupernet;
             return parsed;
@@ -1830,8 +1831,8 @@ namespace System.Net
             }
 
             var supernetted = new List<IPNetwork>();
-            List<IPNetwork> ipns = IPNetwork.Array2List(ipnetworks);
-            Stack<IPNetwork> current = IPNetwork.List2Stack(ipns);
+            List<IPNetwork> ipns = Array2List(ipnetworks);
+            Stack<IPNetwork> current = List2Stack(ipns);
             int previousCount = 0;
             int currentCount = current.Count;
 
@@ -1862,7 +1863,7 @@ namespace System.Net
 
                 previousCount = currentCount;
                 currentCount = supernetted.Count;
-                current = IPNetwork.List2Stack(supernetted);
+                current = List2Stack(supernetted);
             }
 
             supernet = supernetted.ToArray();
@@ -1884,7 +1885,7 @@ namespace System.Net
         {
             var ipns = new List<IPNetwork>();
             ipns.AddRange(array);
-            IPNetwork.RemoveNull(ipns);
+            RemoveNull(ipns);
             ipns.Sort(new Comparison<IPNetwork>(
                 delegate(IPNetwork ipn1, IPNetwork ipn2)
                 {
@@ -1950,7 +1951,7 @@ namespace System.Net
             var ipnetwork = new IPNetwork(0, startIP.AddressFamily, 0);
             for (byte cidr = 32; cidr >= 0; cidr--)
             {
-                var wideSubnet = IPNetwork.Parse(start, cidr);
+                var wideSubnet = Parse(start, cidr);
                 if (wideSubnet.Contains(endIP))
                 {
                     ipnetwork = wideSubnet;
@@ -1963,7 +1964,7 @@ namespace System.Net
 
         public static bool TryWideSubnet(IPNetwork[] ipnetworks, out IPNetwork ipnetwork)
         {
-            IPNetwork.InternalWideSubnet(true, ipnetworks, out IPNetwork ipn);
+            InternalWideSubnet(true, ipnetworks, out IPNetwork ipn);
             if (ipn == null)
             {
                 ipnetwork = null;
@@ -1977,7 +1978,7 @@ namespace System.Net
 
         public static IPNetwork WideSubnet(IPNetwork[] ipnetworks)
         {
-            IPNetwork.InternalWideSubnet(false, ipnetworks, out IPNetwork ipn);
+            InternalWideSubnet(false, ipnetworks, out IPNetwork ipn);
             return ipn;
         }
 
@@ -2116,7 +2117,7 @@ namespace System.Net
                 return false;
             }
 
-            if (!IPNetwork.TryToNetmask(b, family, out IPAddress netmask))
+            if (!TryToNetmask(b, family, out IPAddress netmask))
             {
                 cidr = null;
                 return false;
@@ -2346,7 +2347,7 @@ namespace System.Net
         private IPNetwork(SerializationInfo info, StreamingContext context)
         {
             string sipnetwork = (string)info.GetValue("IPNetwork", typeof(string));
-            var ipnetwork = IPNetwork.Parse(sipnetwork);
+            var ipnetwork = Parse(sipnetwork);
 
             this._ipaddress = ipnetwork._ipaddress;
             this._cidr = ipnetwork._cidr;
@@ -2436,10 +2437,10 @@ namespace System.Net
             get
             {
                 byte cidr = this._family == AddressFamily.InterNetwork ? (byte)32 : (byte)128;
-                BigInteger netmask = IPNetwork.ToUint(cidr, this._family);
+                BigInteger netmask = ToUint(cidr, this._family);
                 BigInteger wildcardmask = netmask - this._netmask;
 
-                return IPNetwork.ToIPAddress(wildcardmask, this._family);
+                return ToIPAddress(wildcardmask, this._family);
             }
         }
         #endregion

--- a/src/System.Net.IPNetwork/IPNetworkCollection.cs
+++ b/src/System.Net.IPNetwork/IPNetworkCollection.cs
@@ -2,12 +2,14 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
-namespace System.Net
-{
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Numerics;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Numerics;
 
+namespace IPNetwork2
+{
     public class IPNetworkCollection : IEnumerable<IPNetwork>, IEnumerator<IPNetwork>
     {
         private BigInteger _enumerator;
@@ -41,7 +43,7 @@ namespace System.Net
 #endif
         IPNetworkCollection(IPNetwork ipnetwork, byte cidrSubnet)
         {
-            int maxCidr = ipnetwork.AddressFamily == Sockets.AddressFamily.InterNetwork ? 32 : 128;
+            int maxCidr = ipnetwork.AddressFamily == AddressFamily.InterNetwork ? 32 : 128;
             if (cidrSubnet > maxCidr)
             {
                 throw new ArgumentOutOfRangeException("cidrSubnet");
@@ -63,7 +65,7 @@ namespace System.Net
         {
             get
             {
-                BigInteger count = BigInteger.Pow(2, this._cidrSubnet - this._cidr);
+                var count = BigInteger.Pow(2, this._cidrSubnet - this._cidr);
                 return count;
             }
         }
@@ -77,7 +79,7 @@ namespace System.Net
                     throw new ArgumentOutOfRangeException("i");
                 }
 
-                BigInteger last = this._ipnetwork.AddressFamily == Sockets.AddressFamily.InterNetworkV6
+                BigInteger last = this._ipnetwork.AddressFamily == AddressFamily.InterNetworkV6
                     ? this._lastUsable : this._broadcast;
                 BigInteger increment = (last - this._network) / this.Count;
                 BigInteger uintNetwork = this._network + ((increment + 1) * i);

--- a/src/System.Net.IPNetwork/System.Net.IPNetwork.csproj
+++ b/src/System.Net.IPNetwork/System.Net.IPNetwork.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net47;net48;netcoreapp3.1;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0</TargetFrameworks> 
+	  <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net47;net48;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0;net8.0</TargetFrameworks> 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 	  <PackageId>IPNetwork2</PackageId>
     <PackageVersion>2.6.0</PackageVersion>

--- a/src/System.Net.IPNetwork/System.Net.IPNetwork.csproj
+++ b/src/System.Net.IPNetwork/System.Net.IPNetwork.csproj
@@ -1,89 +1,88 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-	  <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net47;net48;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0;net8.0</TargetFrameworks> 
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-	  <PackageId>IPNetwork2</PackageId>
-    <PackageVersion>2.6.0</PackageVersion>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <PackageLicenseUrl>https://github.com/lduchosal/ipnetwork/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/lduchosal/ipnetwork</PackageProjectUrl>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageTags>ipnetwork network ip ipv4 ipv6 netmask cidr subnet subnetting supernet supernetting calculation</PackageTags>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net47;net48;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<PackageId>IPNetwork2</PackageId>
+		<PackageVersion>2.6.0</PackageVersion>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<PackageLicenseUrl>https://github.com/lduchosal/ipnetwork/blob/master/LICENSE</PackageLicenseUrl>
+		<PackageProjectUrl>https://github.com/lduchosal/ipnetwork</PackageProjectUrl>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<PackageReleaseNotes></PackageReleaseNotes>
+		<PackageTags>ipnetwork network ip ipv4 ipv6 netmask cidr subnet subnetting supernet supernetting calculation</PackageTags>
 
-    <Title>IPNetwork utility classes for .Net</Title>
-    <Description>IPNetwork C# library take care of complex network, ip, ipv4, ipv6, netmask, cidr, subnet, subnetting, supernet and supernetting calculation for .Net developpers. It works with IPv4 and IPv6 as well. It is written in C# for .NetStandard and coreclr and has a light and clean API and is fully unit tested.</Description>
-    <PackageSummary>IPNetwork utility classes for .Net</PackageSummary>
-    <authors>Luc Dvchosal</authors>
-    <owners>Luc Dvchosal</owners>
-    <copyright>Copyright 2022</copyright>
-    <SignAssembly>True</SignAssembly>
-    <SignAssembly Condition=" '$(OS)' != 'Windows_NT' ">false</SignAssembly>
-    <AssemblyOriginatorKeyFile>System.Net.IPNetwork.snk</AssemblyOriginatorKeyFile>
-    <RepositoryUrl>https://github.com/lduchosal/ipnetwork.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-
+		<Title>IPNetwork utility classes for .Net</Title>
+		<Description>IPNetwork C# library take care of complex network, ip, ipv4, ipv6, netmask, cidr, subnet, subnetting, supernet and supernetting calculation for .Net developpers. It works with IPv4 and IPv6 as well. It is written in C# for .NetStandard and coreclr and has a light and clean API and is fully unit tested.</Description>
+		<PackageSummary>IPNetwork utility classes for .Net</PackageSummary>
+		<authors>Luc Dvchosal</authors>
+		<owners>Luc Dvchosal</owners>
+		<copyright>Copyright 2022</copyright>
+		<SignAssembly>True</SignAssembly>
+		<SignAssembly Condition=" '$(OS)' != 'Windows_NT' ">false</SignAssembly>
+		<AssemblyOriginatorKeyFile>System.Net.IPNetwork.snk</AssemblyOriginatorKeyFile>
+		<RepositoryUrl>https://github.com/lduchosal/ipnetwork.git</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>
-  
-  <PropertyGroup>
-	<DefineConstants Condition="'$(OS)' != 'Windows_NT'">$(DefineConstants);TRAVISCI</DefineConstants>
-	<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
-	<PackageReadmeFile></PackageReadmeFile>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
-    <WarningLevel>5</WarningLevel>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
-    <WarningLevel>5</WarningLevel>
-  </PropertyGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)'=='net40' OR '$(TargetFramework)'=='net45' OR '$(TargetFramework)'=='net46' OR '$(TargetFramework)'=='net47'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <None Remove="stylecop.json" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <AdditionalFiles Include="stylecop.json" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="." />
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Memory" Version="4.5.5">
-    </PackageReference>
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Memory" Version="4.5.5">
-    </PackageReference>
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
-    <PackageReference Include="System.Memory" Version="4.5.5">
-    </PackageReference>
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
-    <PackageReference Include="System.Memory" Version="4.5.5">
-    </PackageReference>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+
+	<PropertyGroup>
+		<DefineConstants Condition="'$(OS)' != 'Windows_NT'">$(DefineConstants);TRAVISCI</DefineConstants>
+		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+		<PackageReadmeFile></PackageReadmeFile>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
+		<WarningLevel>5</WarningLevel>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
+		<WarningLevel>5</WarningLevel>
+	</PropertyGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'=='net46' OR '$(TargetFramework)'=='net47'">
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="Microsoft.CSharp" />
+		<Reference Include="System.Data" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Remove="stylecop.json" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<AdditionalFiles Include="stylecop.json" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\..\LICENSE" Pack="true" PackagePath="." />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="System.Memory" Version="4.5.5">
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+		<PackageReference Include="System.Memory" Version="4.5.5">
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+		<PackageReference Include="System.Memory" Version="4.5.5">
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net47'">
+		<PackageReference Include="System.Memory" Version="4.5.5">
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 </Project>

--- a/src/TestProject/BigIntegerBitWiseUnitTest.cs
+++ b/src/TestProject/BigIntegerBitWiseUnitTest.cs
@@ -2,11 +2,14 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.Numerics;
+
+using IPNetwork2;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace System.Net.TestProject
 {
-    using System.Numerics;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class BigIntegerBitWiseUnitTest
     {

--- a/src/TestProject/BigIntegerBitWiseUnitTest.cs
+++ b/src/TestProject/BigIntegerBitWiseUnitTest.cs
@@ -4,11 +4,9 @@
 
 using System.Numerics;
 
-using IPNetwork2;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     [TestClass]
     public class BigIntegerBitWiseUnitTest

--- a/src/TestProject/BigIntegerToUnitTest.cs
+++ b/src/TestProject/BigIntegerToUnitTest.cs
@@ -4,11 +4,9 @@
 
 using System.Numerics;
 
-using IPNetwork2;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     [TestClass]
     public class BigIntegerToUnitTest

--- a/src/TestProject/BigIntegerToUnitTest.cs
+++ b/src/TestProject/BigIntegerToUnitTest.cs
@@ -2,11 +2,14 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.Numerics;
+
+using IPNetwork2;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace System.Net.TestProject
 {
-    using System.Numerics;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class BigIntegerToUnitTest
     {

--- a/src/TestProject/CidrClassFullUnitTest.cs
+++ b/src/TestProject/CidrClassFullUnitTest.cs
@@ -2,10 +2,12 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using IPNetwork2;
+
 namespace System.Net.TestProject
 {
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class CidrClassFullUnitTest
     {

--- a/src/TestProject/CidrClassFullUnitTest.cs
+++ b/src/TestProject/CidrClassFullUnitTest.cs
@@ -4,9 +4,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using IPNetwork2;
-
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     [TestClass]
     public class CidrClassFullUnitTest

--- a/src/TestProject/CidrClassLessUnitTest.cs
+++ b/src/TestProject/CidrClassLessUnitTest.cs
@@ -4,9 +4,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using IPNetwork2;
-
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     [TestClass]
     public class CidrClassLessUnitTest

--- a/src/TestProject/CidrClassLessUnitTest.cs
+++ b/src/TestProject/CidrClassLessUnitTest.cs
@@ -2,10 +2,12 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using IPNetwork2;
+
 namespace System.Net.TestProject
 {
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class CidrClassLessUnitTest
     {

--- a/src/TestProject/ConsoleUnitTest.cs
+++ b/src/TestProject/ConsoleUnitTest.cs
@@ -4,7 +4,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     [TestClass]
     public class ConsoleUnitTest

--- a/src/TestProject/ConsoleUnitTest.cs
+++ b/src/TestProject/ConsoleUnitTest.cs
@@ -2,10 +2,10 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace System.Net.TestProject
 {
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class ConsoleUnitTest
     {

--- a/src/TestProject/ContainsUnitTest.cs
+++ b/src/TestProject/ContainsUnitTest.cs
@@ -2,11 +2,12 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System;
+using System.Net;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using IPNetwork2;
-
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     /// <summary>
     /// ContainsUnitTest test every Contiains method.

--- a/src/TestProject/ContainsUnitTest.cs
+++ b/src/TestProject/ContainsUnitTest.cs
@@ -2,10 +2,12 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using IPNetwork2;
+
 namespace System.Net.TestProject
 {
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     /// <summary>
     /// ContainsUnitTest test every Contiains method.
     /// </summary>

--- a/src/TestProject/DataContractSerializeHelper.cs
+++ b/src/TestProject/DataContractSerializeHelper.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Runtime.Serialization;
 using System.Xml;
 
-namespace System.Net.TestSerialization.NetFramework
+namespace IPNetwork2.TestSerialization.NetFramework
 {
     public static class DataContractSerializeHelper
     {

--- a/src/TestProject/DataContractSerializeHelper.cs
+++ b/src/TestProject/DataContractSerializeHelper.cs
@@ -2,12 +2,12 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.IO;
+using System.Runtime.Serialization;
+using System.Xml;
+
 namespace System.Net.TestSerialization.NetFramework
 {
-    using System.IO;
-    using System.Runtime.Serialization;
-    using System.Xml;
-
     public static class DataContractSerializeHelper
     {
         public static string Serialize<T>(T obj, bool formatting = true)

--- a/src/TestProject/EqualsUnitTest.cs
+++ b/src/TestProject/EqualsUnitTest.cs
@@ -4,9 +4,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using IPNetwork2;
-
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     [TestClass]
     public class EqualsUnitTest

--- a/src/TestProject/EqualsUnitTest.cs
+++ b/src/TestProject/EqualsUnitTest.cs
@@ -2,10 +2,12 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using IPNetwork2;
+
 namespace System.Net.TestProject
 {
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class EqualsUnitTest
     {

--- a/src/TestProject/GetHashCodeUnitTest.cs
+++ b/src/TestProject/GetHashCodeUnitTest.cs
@@ -4,11 +4,9 @@
 
 using System.Collections.Generic;
 
-using IPNetwork2;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     [TestClass]
     public class GetHashCodeUnitTest

--- a/src/TestProject/GetHashCodeUnitTest.cs
+++ b/src/TestProject/GetHashCodeUnitTest.cs
@@ -2,11 +2,14 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.Collections.Generic;
+
+using IPNetwork2;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace System.Net.TestProject
 {
-    using System.Collections.Generic;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class GetHashCodeUnitTest
     {

--- a/src/TestProject/HashSetUnitTest.cs
+++ b/src/TestProject/HashSetUnitTest.cs
@@ -4,11 +4,9 @@
 
 using System.Collections.Generic;
 
-using IPNetwork2;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     [TestClass]
     public class HashSetUnitTest

--- a/src/TestProject/HashSetUnitTest.cs
+++ b/src/TestProject/HashSetUnitTest.cs
@@ -2,11 +2,14 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.Collections.Generic;
+
+using IPNetwork2;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace System.Net.TestProject
 {
-    using System.Collections.Generic;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class HashSetUnitTest
     {

--- a/src/TestProject/IPAddressCollectionUnitTest.cs
+++ b/src/TestProject/IPAddressCollectionUnitTest.cs
@@ -2,15 +2,15 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Net;
 using System.Numerics;
-
-using IPNetwork2;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     /// <summary>
     /// IPNetworkUnitTest test every single method.

--- a/src/TestProject/IPAddressCollectionUnitTest.cs
+++ b/src/TestProject/IPAddressCollectionUnitTest.cs
@@ -2,13 +2,16 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.Collections;
+using System.Collections.Generic;
+using System.Numerics;
+
+using IPNetwork2;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace System.Net.TestProject
 {
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Numerics;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     /// <summary>
     /// IPNetworkUnitTest test every single method.
     /// </summary>

--- a/src/TestProject/IPAddressExtensionTests.cs
+++ b/src/TestProject/IPAddressExtensionTests.cs
@@ -2,12 +2,15 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.Collections.Generic;
+using System.Linq;
+
+using IPNetwork2;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace System.Net.TestProject
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     /// <summary>
     /// A collection of unit tests exercising the IPAddressExtensions class.
     /// </summary>

--- a/src/TestProject/IPAddressExtensionTests.cs
+++ b/src/TestProject/IPAddressExtensionTests.cs
@@ -2,14 +2,16 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 
 using IPNetwork2;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     /// <summary>
     /// A collection of unit tests exercising the IPAddressExtensions class.

--- a/src/TestProject/IPNetworkCollectionUnitTest.cs
+++ b/src/TestProject/IPNetworkCollectionUnitTest.cs
@@ -2,10 +2,12 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using IPNetwork2;
+
 namespace System.Net.TestProject
 {
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class IPNetworkCollectionUnitTest
     {

--- a/src/TestProject/IPNetworkCollectionUnitTest.cs
+++ b/src/TestProject/IPNetworkCollectionUnitTest.cs
@@ -2,11 +2,12 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System;
+using System.Collections;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using IPNetwork2;
-
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     [TestClass]
     public class IPNetworkCollectionUnitTest
@@ -37,7 +38,7 @@ namespace System.Net.TestProject
             var ipn = IPNetwork.Parse("192.168.0.0/32");
             using (IPNetworkCollection ipns = ipn.Subnet(32))
             {
-                var ipnse = (Collections.IEnumerator)ipns;
+                var ipnse = (IEnumerator)ipns;
                 ipnse.MoveNext();
                 object ipn0 = ipnse.Current;
 
@@ -55,8 +56,8 @@ namespace System.Net.TestProject
             var ipn = IPNetwork.Parse("192.168.0.0/32");
             using (IPNetworkCollection ipns = ipn.Subnet(32))
             {
-                var ipnse = (Collections.IEnumerable)ipns;
-                Collections.IEnumerator ee = ipnse.GetEnumerator();
+                var ipnse = (IEnumerable)ipns;
+                IEnumerator ee = ipnse.GetEnumerator();
                 ee.MoveNext();
                 object ipn0 = ee.Current;
                 Assert.AreEqual("192.168.0.0/32", ipn0.ToString(), "ipn0");

--- a/src/TestProject/IPNetworkUnitTest.cs
+++ b/src/TestProject/IPNetworkUnitTest.cs
@@ -2,15 +2,17 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System;
+using System.Net.Sockets;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 
-using IPNetwork2;
+using System.Net;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     /// <summary>
     /// IPNetworkUnitTest test every single method.
@@ -24,7 +26,7 @@ namespace System.Net.TestProject
         [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void TestCtor1()
         {
-            new IPNetwork(BigInteger.Zero, Sockets.AddressFamily.InterNetwork, 33);
+            new IPNetwork(BigInteger.Zero, AddressFamily.InterNetwork, 33);
         }
         #endregion
 
@@ -1178,13 +1180,13 @@ namespace System.Net.TestProject
         [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void TestToBigIntegerByte()
         {
-            BigInteger result = IPNetwork.ToUint(33, Sockets.AddressFamily.InterNetwork);
+            BigInteger result = IPNetwork.ToUint(33, AddressFamily.InterNetwork);
         }
 
         [TestMethod]
         public void TestToBigIntegerByte2()
         {
-            BigInteger result = IPNetwork.ToUint(32, Sockets.AddressFamily.InterNetwork);
+            BigInteger result = IPNetwork.ToUint(32, AddressFamily.InterNetwork);
             uint expected = 4294967295;
             Assert.AreEqual(expected, result, "result");
         }
@@ -1192,7 +1194,7 @@ namespace System.Net.TestProject
         [TestMethod]
         public void TestToBigIntegerByte3()
         {
-            BigInteger result = IPNetwork.ToUint(0, Sockets.AddressFamily.InterNetwork);
+            BigInteger result = IPNetwork.ToUint(0, AddressFamily.InterNetwork);
             uint expected = 0;
             Assert.AreEqual(expected, result, "result");
         }
@@ -1201,7 +1203,7 @@ namespace System.Net.TestProject
         public void TestToBigIntegerInternal1()
         {
             BigInteger? result = null;
-            IPNetwork.InternalToBigInteger(true, 33, Sockets.AddressFamily.InterNetwork, out result);
+            IPNetwork.InternalToBigInteger(true, 33, AddressFamily.InterNetwork, out result);
             Assert.AreEqual(null, result, "result");
         }
 
@@ -1209,7 +1211,7 @@ namespace System.Net.TestProject
         public void TestToBigIntegerInternal2()
         {
             BigInteger? result = null;
-            IPNetwork.InternalToBigInteger(true, 129, Sockets.AddressFamily.InterNetworkV6, out result);
+            IPNetwork.InternalToBigInteger(true, 129, AddressFamily.InterNetworkV6, out result);
             Assert.AreEqual(null, result, "result");
         }
 
@@ -1218,7 +1220,7 @@ namespace System.Net.TestProject
         public void TestToBigIntegerInternal3()
         {
             BigInteger? result = null;
-            IPNetwork.InternalToBigInteger(false, 129, Sockets.AddressFamily.InterNetworkV6, out result);
+            IPNetwork.InternalToBigInteger(false, 129, AddressFamily.InterNetworkV6, out result);
         }
 
         [TestMethod]
@@ -1226,14 +1228,14 @@ namespace System.Net.TestProject
         public void TestToBigIntegerInternal4()
         {
             BigInteger? result = null;
-            IPNetwork.InternalToBigInteger(false, 32, Sockets.AddressFamily.AppleTalk, out result);
+            IPNetwork.InternalToBigInteger(false, 32, AddressFamily.AppleTalk, out result);
         }
 
         [TestMethod]
         public void TestToBigIntegerInternal5()
         {
             BigInteger? result = null;
-            IPNetwork.InternalToBigInteger(true, 32, Sockets.AddressFamily.AppleTalk, out result);
+            IPNetwork.InternalToBigInteger(true, 32, AddressFamily.AppleTalk, out result);
             Assert.AreEqual(null, result, "result");
         }
 
@@ -1245,7 +1247,7 @@ namespace System.Net.TestProject
         public void TestTryToUint1()
         {
             BigInteger? result = null;
-            bool parsed = IPNetwork.TryToUint(32, Sockets.AddressFamily.InterNetwork, out result);
+            bool parsed = IPNetwork.TryToUint(32, AddressFamily.InterNetwork, out result);
 
             Assert.IsNotNull(result, "uint");
             Assert.AreEqual(true, parsed, "parsed");
@@ -1354,7 +1356,7 @@ namespace System.Net.TestProject
         public void TryToNetmask1()
         {
             IPAddress result = null;
-            bool parsed = IPNetwork.TryToNetmask(0, Sockets.AddressFamily.InterNetwork, out result);
+            bool parsed = IPNetwork.TryToNetmask(0, AddressFamily.InterNetwork, out result);
             var expected = IPAddress.Parse("0.0.0.0");
 
             Assert.AreEqual(expected, result, "Netmask");
@@ -1365,7 +1367,7 @@ namespace System.Net.TestProject
         public void TryToNetmask2()
         {
             IPAddress result = null;
-            bool parsed = IPNetwork.TryToNetmask(33, Sockets.AddressFamily.InterNetwork, out result);
+            bool parsed = IPNetwork.TryToNetmask(33, AddressFamily.InterNetwork, out result);
             IPAddress expected = null;
 
             Assert.AreEqual(expected, result, "Netmask");
@@ -1381,7 +1383,7 @@ namespace System.Net.TestProject
         {
             byte cidr = 32;
             string netmask = "255.255.255.255";
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetwork).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetwork).ToString();
 
             Assert.AreEqual(netmask, result, "netmask");
         }
@@ -1391,7 +1393,7 @@ namespace System.Net.TestProject
         public void ToNetmaskNonInet()
         {
             byte cidr = 0;
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.AppleTalk).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.AppleTalk).ToString();
         }
 
         [TestMethod]
@@ -1400,14 +1402,14 @@ namespace System.Net.TestProject
         {
             byte cidr = 0;
             cidr--;
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetwork).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetwork).ToString();
         }
 
         [TestMethod]
         public void ToNetmaskInternal1()
         {
             IPAddress result;
-            IPNetwork.InternalToNetmask(true, 0, Sockets.AddressFamily.AppleTalk, out result);
+            IPNetwork.InternalToNetmask(true, 0, AddressFamily.AppleTalk, out result);
             Assert.AreEqual(null, result);
         }
 
@@ -1416,7 +1418,7 @@ namespace System.Net.TestProject
         {
             byte cidr = 31;
             string netmask = "255.255.255.254";
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetwork).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetwork).ToString();
 
             Assert.AreEqual(netmask, result, "netmask");
         }
@@ -1426,7 +1428,7 @@ namespace System.Net.TestProject
         {
             byte cidr = 30;
             string netmask = "255.255.255.252";
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetwork).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetwork).ToString();
 
             Assert.AreEqual(netmask, result, "netmask");
         }
@@ -1436,7 +1438,7 @@ namespace System.Net.TestProject
         {
             byte cidr = 29;
             string netmask = "255.255.255.248";
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetwork).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetwork).ToString();
 
             Assert.AreEqual(netmask, result, "netmask");
         }
@@ -1446,7 +1448,7 @@ namespace System.Net.TestProject
         {
             byte cidr = 1;
             string netmask = "128.0.0.0";
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetwork).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetwork).ToString();
 
             Assert.AreEqual(netmask, result, "netmask");
         }
@@ -1456,7 +1458,7 @@ namespace System.Net.TestProject
         {
             byte cidr = 0;
             string netmask = "0.0.0.0";
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetwork).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetwork).ToString();
 
             Assert.AreEqual(netmask, result, "netmask");
         }
@@ -1466,7 +1468,7 @@ namespace System.Net.TestProject
         public void ToNetmaskOORE1()
         {
             byte cidr = 33;
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetwork).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetwork).ToString();
         }
 
         #endregion
@@ -1477,7 +1479,7 @@ namespace System.Net.TestProject
         public void TestToIPAddress()
         {
             var ip = new BigInteger(0);
-            var result = IPNetwork.ToIPAddress(ip, Sockets.AddressFamily.InterNetwork);
+            var result = IPNetwork.ToIPAddress(ip, AddressFamily.InterNetwork);
             Assert.AreEqual(IPAddress.Any, result, "ToIPAddress");
         }
 
@@ -1486,7 +1488,7 @@ namespace System.Net.TestProject
         public void TestToIPAddress2()
         {
             var ip = new BigInteger(0);
-            var result = IPNetwork.ToIPAddress(ip, Sockets.AddressFamily.AppleTalk);
+            var result = IPNetwork.ToIPAddress(ip, AddressFamily.AppleTalk);
         }
 
         [TestMethod]
@@ -1505,7 +1507,7 @@ namespace System.Net.TestProject
                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
             });
-            var result = IPNetwork.ToIPAddress(ip, Sockets.AddressFamily.AppleTalk);
+            var result = IPNetwork.ToIPAddress(ip, AddressFamily.AppleTalk);
         }
         #endregion
 
@@ -1515,7 +1517,7 @@ namespace System.Net.TestProject
         [ExpectedException(typeof(ArgumentException))]
         public void TestValidNetmaskInvalid1()
         {
-            bool resut = IPNetwork.InternalValidNetmask(BigInteger.Zero, Sockets.AddressFamily.AppleTalk);
+            bool resut = IPNetwork.InternalValidNetmask(BigInteger.Zero, AddressFamily.AppleTalk);
         }
 
         [TestMethod]
@@ -3410,7 +3412,7 @@ Usable      : 4294967294
         [ExpectedException(typeof(ArgumentException))]
         public void TestResize1()
         {
-            byte[] resut = IPNetwork.Resize(new byte[33], Sockets.AddressFamily.InterNetwork);
+            byte[] resut = IPNetwork.Resize(new byte[33], AddressFamily.InterNetwork);
         }
 
         #endregion
@@ -3542,7 +3544,7 @@ Usable      : 4294967294
             string sidr = "0";
             byte? cidr;
             byte? result = 0;
-            bool parsed = IPNetwork.TryParseCidr(sidr, Sockets.AddressFamily.InterNetwork, out cidr);
+            bool parsed = IPNetwork.TryParseCidr(sidr, AddressFamily.InterNetwork, out cidr);
 
             Assert.AreEqual(true, parsed, "parsed");
             Assert.AreEqual(result, cidr, "cidr");
@@ -3555,7 +3557,7 @@ Usable      : 4294967294
             byte? cidr;
             byte? result = null;
 
-            bool parsed = IPNetwork.TryParseCidr(sidr, Sockets.AddressFamily.InterNetwork, out cidr);
+            bool parsed = IPNetwork.TryParseCidr(sidr, AddressFamily.InterNetwork, out cidr);
 
             Assert.AreEqual(false, parsed, "parsed");
             Assert.AreEqual(result, cidr, "cidr");
@@ -3568,7 +3570,7 @@ Usable      : 4294967294
             byte? cidr;
             byte? result = null;
 
-            bool parsed = IPNetwork.TryParseCidr(sidr, Sockets.AddressFamily.InterNetwork, out cidr);
+            bool parsed = IPNetwork.TryParseCidr(sidr, AddressFamily.InterNetwork, out cidr);
 
             Assert.AreEqual(false, parsed, "parsed");
             Assert.AreEqual(result, cidr, "cidr");

--- a/src/TestProject/IPNetworkUnitTest.cs
+++ b/src/TestProject/IPNetworkUnitTest.cs
@@ -2,13 +2,16 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+
+using IPNetwork2;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace System.Net.TestProject
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Numerics;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     /// <summary>
     /// IPNetworkUnitTest test every single method.
     /// </summary>

--- a/src/TestProject/IPNetworkV6UnitTest.cs
+++ b/src/TestProject/IPNetworkV6UnitTest.cs
@@ -2,11 +2,14 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.Numerics;
+
+using IPNetwork2;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace System.Net.TestProject
 {
-    using System.Numerics;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class IPNetworkV6UnitTest
     {

--- a/src/TestProject/IPNetworkV6UnitTest.cs
+++ b/src/TestProject/IPNetworkV6UnitTest.cs
@@ -2,13 +2,14 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System;
+using System.Net;
+using System.Net.Sockets;
 using System.Numerics;
-
-using IPNetwork2;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     [TestClass]
     public class IPNetworkV6UnitTest
@@ -1508,7 +1509,7 @@ namespace System.Net.TestProject
         public void TryToNetmask1()
         {
             IPAddress result = null;
-            bool parsed = IPNetwork.TryToNetmask(0, Sockets.AddressFamily.InterNetworkV6, out result);
+            bool parsed = IPNetwork.TryToNetmask(0, AddressFamily.InterNetworkV6, out result);
             var expected = IPAddress.Parse("::");
 
             Assert.AreEqual(expected, result, "Netmask");
@@ -1519,7 +1520,7 @@ namespace System.Net.TestProject
         public void TryToNetmask2()
         {
             IPAddress result = null;
-            bool parsed = IPNetwork.TryToNetmask(33, Sockets.AddressFamily.InterNetworkV6, out result);
+            bool parsed = IPNetwork.TryToNetmask(33, AddressFamily.InterNetworkV6, out result);
             var expected = IPAddress.Parse("ffff:ffff:8000::");
 
             Assert.AreEqual(expected, result, "Netmask");
@@ -1535,7 +1536,7 @@ namespace System.Net.TestProject
         {
             byte cidr = 128;
             string netmask = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff";
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetworkV6).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetworkV6).ToString();
 
             Assert.AreEqual(netmask, result, "netmask");
         }
@@ -1545,7 +1546,7 @@ namespace System.Net.TestProject
         {
             byte cidr = 127;
             string netmask = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe";
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetworkV6).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetworkV6).ToString();
 
             Assert.AreEqual(netmask, result, "netmask");
         }
@@ -1555,7 +1556,7 @@ namespace System.Net.TestProject
         {
             byte cidr = 126;
             string netmask = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffc";
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetworkV6).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetworkV6).ToString();
 
             Assert.AreEqual(netmask, result, "netmask");
         }
@@ -1565,7 +1566,7 @@ namespace System.Net.TestProject
         {
             byte cidr = 1;
             string netmask = "8000::";
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetworkV6).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetworkV6).ToString();
 
             Assert.AreEqual(netmask, result, "netmask");
         }
@@ -1575,7 +1576,7 @@ namespace System.Net.TestProject
         {
             byte cidr = 0;
             string netmask = "::";
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetworkV6).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetworkV6).ToString();
 
             Assert.AreEqual(netmask, result, "netmask");
         }
@@ -1585,7 +1586,7 @@ namespace System.Net.TestProject
         public void ToNetmaskOORE1()
         {
             byte cidr = 129;
-            string result = IPNetwork.ToNetmask(cidr, Sockets.AddressFamily.InterNetworkV6).ToString();
+            string result = IPNetwork.ToNetmask(cidr, AddressFamily.InterNetworkV6).ToString();
         }
 
         #endregion
@@ -2517,7 +2518,7 @@ namespace System.Net.TestProject
             string sidr = "0";
             byte? cidr;
             byte? result = 0;
-            bool parsed = IPNetwork.TryParseCidr(sidr, Sockets.AddressFamily.InterNetworkV6, out cidr);
+            bool parsed = IPNetwork.TryParseCidr(sidr, AddressFamily.InterNetworkV6, out cidr);
 
             Assert.AreEqual(true, parsed, "parsed");
             Assert.AreEqual(result, cidr, "cidr");
@@ -2530,7 +2531,7 @@ namespace System.Net.TestProject
             byte? cidr;
             byte? result = null;
 
-            bool parsed = IPNetwork.TryParseCidr(sidr, Sockets.AddressFamily.InterNetworkV6, out cidr);
+            bool parsed = IPNetwork.TryParseCidr(sidr, AddressFamily.InterNetworkV6, out cidr);
 
             Assert.AreEqual(false, parsed, "parsed");
             Assert.AreEqual(result, cidr, "cidr");
@@ -2543,7 +2544,7 @@ namespace System.Net.TestProject
             byte? cidr;
             byte result = 33;
 
-            bool parsed = IPNetwork.TryParseCidr(sidr, Sockets.AddressFamily.InterNetworkV6, out cidr);
+            bool parsed = IPNetwork.TryParseCidr(sidr, AddressFamily.InterNetworkV6, out cidr);
 
             Assert.AreEqual(true, parsed, "parsed");
             Assert.AreEqual(result, cidr, "cidr");
@@ -2556,7 +2557,7 @@ namespace System.Net.TestProject
             byte? cidr;
             byte result = 128;
 
-            bool parsed = IPNetwork.TryParseCidr(sidr, Sockets.AddressFamily.InterNetworkV6, out cidr);
+            bool parsed = IPNetwork.TryParseCidr(sidr, AddressFamily.InterNetworkV6, out cidr);
 
             Assert.AreEqual(true, parsed, "parsed");
             Assert.AreEqual(result, cidr, "cidr");
@@ -2569,7 +2570,7 @@ namespace System.Net.TestProject
             byte? cidr;
             byte? result = null;
 
-            bool parsed = IPNetwork.TryParseCidr(sidr, Sockets.AddressFamily.InterNetworkV6, out cidr);
+            bool parsed = IPNetwork.TryParseCidr(sidr, AddressFamily.InterNetworkV6, out cidr);
 
             Assert.AreEqual(false, parsed, "parsed");
             Assert.AreEqual(result, cidr, "cidr");

--- a/src/TestProject/SerializeBinaryFormatterTest.cs
+++ b/src/TestProject/SerializeBinaryFormatterTest.cs
@@ -2,14 +2,17 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+
+using IPNetwork2;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
 
 namespace System.Net.TestSerialization
 {
-    using System.IO;
-    using System.Runtime.Serialization.Formatters.Binary;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class SerializeBinaryFormatterTest
     {

--- a/src/TestProject/SerializeBinaryFormatterTest.cs
+++ b/src/TestProject/SerializeBinaryFormatterTest.cs
@@ -2,16 +2,15 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
-
-using IPNetwork2;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
 
-namespace System.Net.TestSerialization
+namespace IPNetwork2.TestSerialization
 {
     [TestClass]
     public class SerializeBinaryFormatterTest

--- a/src/TestProject/SerializeDataContractTest.cs
+++ b/src/TestProject/SerializeDataContractTest.cs
@@ -2,11 +2,11 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using IPNetwork2;
-
-namespace System.Net.TestSerialization.NetFramework
+namespace IPNetwork2.TestSerialization.NetFramework
 {
     [TestClass]
     public class SerializeDataContractTest

--- a/src/TestProject/SerializeDataContractTest.cs
+++ b/src/TestProject/SerializeDataContractTest.cs
@@ -2,10 +2,12 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using IPNetwork2;
+
 namespace System.Net.TestSerialization.NetFramework
 {
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class SerializeDataContractTest
     {

--- a/src/TestProject/SerializeJsonTest.cs
+++ b/src/TestProject/SerializeJsonTest.cs
@@ -4,11 +4,9 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using IPNetwork2;
-
 using Newtonsoft.Json;
 
-namespace System.Net.TestSerialization.NetFramework
+namespace IPNetwork2.TestSerialization.NetFramework
 {
     [TestClass]
     public class SerializeJsonTest

--- a/src/TestProject/SerializeJsonTest.cs
+++ b/src/TestProject/SerializeJsonTest.cs
@@ -2,11 +2,14 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using IPNetwork2;
+
+using Newtonsoft.Json;
+
 namespace System.Net.TestSerialization.NetFramework
 {
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Newtonsoft.Json;
-
     [TestClass]
     public class SerializeJsonTest
     {

--- a/src/TestProject/SerializeXmlTest.cs
+++ b/src/TestProject/SerializeXmlTest.cs
@@ -2,15 +2,14 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System;
 using System.IO;
 using System.Text;
 using System.Xml.Serialization;
 
-using IPNetwork2;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace System.Net.TestSerialization.NetFramework
+namespace IPNetwork2.TestSerialization.NetFramework
 {
     [TestClass]
     public class SerializeXmlTest

--- a/src/TestProject/SerializeXmlTest.cs
+++ b/src/TestProject/SerializeXmlTest.cs
@@ -2,13 +2,16 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.IO;
+using System.Text;
+using System.Xml.Serialization;
+
+using IPNetwork2;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace System.Net.TestSerialization.NetFramework
 {
-    using System.IO;
-    using System.Text;
-    using System.Xml.Serialization;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class SerializeXmlTest
     {

--- a/src/TestProject/TestProject.csproj
+++ b/src/TestProject/TestProject.csproj
@@ -1,87 +1,84 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-	  <TargetFrameworks>net462;net47;net48;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
-	  <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net8.0</TargetFrameworks>
+	<PropertyGroup>
+		<TargetFrameworks>net462;net47;net48;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net8.0</TargetFrameworks>
 
+		<IsPackable>false</IsPackable>
 
-	  <IsPackable>false</IsPackable>
+		<SignAssembly>True</SignAssembly>
+		<SignAssembly Condition="'$(OS)' != 'Windows_NT'">false</SignAssembly>
 
+		<AssemblyOriginatorKeyFile>..\System.Net.IPNetwork.snk</AssemblyOriginatorKeyFile>
 
-	  <SignAssembly>True</SignAssembly>
-	  <SignAssembly Condition="'$(OS)' != 'Windows_NT'">false</SignAssembly>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+	</PropertyGroup>
 
-	  <AssemblyOriginatorKeyFile>..\System.Net.IPNetwork.snk</AssemblyOriginatorKeyFile>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net47|AnyCPU'">
+		<DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
+	</PropertyGroup>
 
-	  <EnableNETAnalyzers>true</EnableNETAnalyzers>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net47|AnyCPU'">
+		<DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net47|AnyCPU'">
-    <DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net48|AnyCPU'">
+		<DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net47|AnyCPU'">
-    <DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net48|AnyCPU'">
+		<DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net48|AnyCPU'">
-    <DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
+		<DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net48|AnyCPU'">
-    <DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|AnyCPU'">
+		<DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
-    <DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
+		<DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|AnyCPU'">
-    <DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
+		<DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0|AnyCPU'">
-    <DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
+		<DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net7.0|AnyCPU'">
-    <DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
+		<DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
-    <DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
-  </PropertyGroup>
+	<ItemGroup>
+		<None Remove="stylecop.json" />
+	</ItemGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
-    <DefineConstants>$(DefineConstants)TRACE;TRAVISCI</DefineConstants>
-  </PropertyGroup>
+	<ItemGroup>
+		<AdditionalFiles Include="stylecop.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Remove="stylecop.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="stylecop.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeCoverage" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-  </ItemGroup>
-
+	<ItemGroup>
+		<PackageReference Include="coverlet.msbuild" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeCoverage" Version="17.8.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="System.Collections" Version="4.3.0" />
+	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net40' OR '$(TargetFramework)'=='net45' OR '$(TargetFramework)'=='net46'">
 		<Reference Include="System" />
@@ -90,10 +87,9 @@
 		<Reference Include="System.Data" />
 	</ItemGroup>
 
-
 	<ItemGroup>
-	  <ProjectReference Include="..\ConsoleApplication\ConsoleApplication.csproj" />
-	  <ProjectReference Include="..\System.Net.IPNetwork\System.Net.IPNetwork.csproj" />
+		<ProjectReference Include="..\ConsoleApplication\ConsoleApplication.csproj" />
+		<ProjectReference Include="..\System.Net.IPNetwork\System.Net.IPNetwork.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/TestProject/TestProject.csproj
+++ b/src/TestProject/TestProject.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;net47;net48;netcoreapp3.1;net6.0</TargetFrameworks>
-	  <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;net47;net48;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+	  <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net8.0</TargetFrameworks>
 
 
 	  <IsPackable>false</IsPackable>

--- a/src/TestProject/TestProject.csproj
+++ b/src/TestProject/TestProject.csproj
@@ -74,7 +74,7 @@
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/TestProject/TryParseUnitTest.cs
+++ b/src/TestProject/TryParseUnitTest.cs
@@ -2,10 +2,12 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using IPNetwork2;
+
 namespace System.Net.TestProject
 {
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     /// <summary>
     /// IPNetworkUnitTest test every single method.
     /// </summary>

--- a/src/TestProject/TryParseUnitTest.cs
+++ b/src/TestProject/TryParseUnitTest.cs
@@ -2,11 +2,11 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.Net;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using IPNetwork2;
-
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     /// <summary>
     /// IPNetworkUnitTest test every single method.

--- a/src/TestProject/WildcardMaskUnitTest.cs
+++ b/src/TestProject/WildcardMaskUnitTest.cs
@@ -2,11 +2,11 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using System.Net;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using IPNetwork2;
-
-namespace System.Net.TestProject
+namespace IPNetwork2.TestProject
 {
     [TestClass]
     public class WildcardMaskUnitTest

--- a/src/TestProject/WildcardMaskUnitTest.cs
+++ b/src/TestProject/WildcardMaskUnitTest.cs
@@ -2,10 +2,12 @@
 // Copyright (c) IPNetwork. All rights reserved.
 // </copyright>
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using IPNetwork2;
+
 namespace System.Net.TestProject
 {
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
     [TestClass]
     public class WildcardMaskUnitTest
     {


### PR DESCRIPTION
Main reason - https://github.com/lduchosal/ipnetwork/issues/280

There is some unit tests that currently doesn't work because they require rewrite namespace name inside base64 code.
![image](https://github.com/lduchosal/ipnetwork/assets/54151358/d4ebeb9a-ad77-4b9a-a831-17f6317f452b)
