### PR TITLE
Update README.md - Updated API Docs to dndocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=lduchosal_ipnetwork&metric=bugs)](https://sonarcloud.io/summary/new_code?id=lduchosal_ipnetwork)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=lduchosal_ipnetwork&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=lduchosal_ipnetwork)
 [![SecurityCodeScan](https://github.com/lduchosal/ipnetwork/actions/workflows/securitycodescan.yml/badge.svg)](https://github.com/lduchosal/ipnetwork/actions/workflows/securitycodescan.yml)
-[![Static Badge](https://img.shields.io/badge/API%20Documentation-RobiniaDocs-43bc00?logo=readme&logoColor=white)](https://www.robiniadocs.com/d/ipnetwork/)
+[![Static Badge](https://img.shields.io/badge/API%20Docs-DNDocs-190088?logo=readme&logoColor=white)](https://dndocs.com/d/ipnetwork/api/System.Net.html)
 
 
 IPNetwork command line and C# library take care of complex network, IP, IPv4, IPv6, netmask, CIDR, subnet, subnetting, supernet, and supernetting calculation for .NET developers. It works with IPv4 as well as IPv6, is written in C#, has a light and clean API, and is fully unit-tested.


### PR DESCRIPTION
Domain name of API Documentation was changed to 'https://dndocs.com/' therefore url need to be updated to point to valid location.
Domain 'www.robiniadocs.com' will be removed.