### PR TITLE
feat: re-enable netstandard2.0 with Windows/net48 CI gate

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -55,4 +55,4 @@ jobs:
     - name: Build TestProject (net48)
       run: dotnet build ./src/TestProject/TestProject.csproj -c Debug -f net48 --no-restore
     - name: Run net48 tests against netstandard2.0 build
-      run: ./src/TestProject/bin/Debug/net48/TestProject.exe
+      run: dotnet test ./src/TestProject/TestProject.csproj -c Debug -f net48 --no-build --logger "console;verbosity=normal"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -39,3 +39,20 @@ jobs:
       with:
         file: coverage.lcov
         format: lcov
+
+  windows-net48:
+    name: Test net48 (Windows)
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+    - name: Restore
+      run: dotnet restore ./src --verbosity m
+    - name: Build TestProject (net48)
+      run: dotnet build ./src/TestProject/TestProject.csproj -c Debug -f net48 --no-restore
+    - name: Run net48 tests against netstandard2.0 build
+      run: ./src/TestProject/bin/Debug/net48/TestProject.exe

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -55,4 +55,6 @@ jobs:
     - name: Build TestProject (net48)
       run: dotnet build ./src/TestProject/TestProject.csproj -c Debug -f net48 --no-restore
     - name: Run net48 tests against netstandard2.0 build
-      run: dotnet test ./src/TestProject/TestProject.csproj -c Debug -f net48 --no-build --logger "console;verbosity=normal"
+      run: |
+        & .\src\TestProject\bin\Debug\net48\TestProject.exe
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/src/System.Net.IPNetwork/CidrNetworkAware.cs
+++ b/src/System.Net.IPNetwork/CidrNetworkAware.cs
@@ -69,13 +69,13 @@ public sealed class CidrNetworkAware : ICidrGuess
 
         // Reject if user passed a slash - this API expects a plain address.
         // (You can relax this if you want to honor an explicitly supplied prefix.)
-        if (ip.Contains('/'))
+        if (ip!.IndexOf('/') >= 0)
             return false;
 
         if (!IPAddress.TryParse(ip.Trim(), out var ipAddress))
             return false;
 
-        switch (ipAddress.AddressFamily)
+        switch (ipAddress!.AddressFamily)
         {
             case AddressFamily.InterNetwork:
                 cidr = GuessIpv4(ipAddress);

--- a/src/System.Net.IPNetwork/IPNetwork2WideSubnet.cs
+++ b/src/System.Net.IPNetwork/IPNetwork2WideSubnet.cs
@@ -141,7 +141,7 @@ public sealed partial class IPNetwork2
         IPNetwork2 nnin0 = nnin[0];
         BigInteger uintNnin0 = nnin0.ipaddress;
 
-        IPNetwork2 nninX = nnin[^1];
+        IPNetwork2 nninX = nnin[nnin.Length - 1];
         IPAddress ipaddressX = nninX.Last;
 
         AddressFamily family = ipnetworks[0].family;

--- a/src/System.Net.IPNetwork/Polyfills.cs
+++ b/src/System.Net.IPNetwork/Polyfills.cs
@@ -1,0 +1,15 @@
+// <copyright file="Polyfills.cs" company="IPNetwork">
+// Copyright (c) IPNetwork. All rights reserved.
+// </copyright>
+
+#if NETSTANDARD2_0
+namespace System.Diagnostics.CodeAnalysis;
+
+[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+internal sealed class NotNullWhenAttribute : Attribute
+{
+    public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+    public bool ReturnValue { get; }
+}
+#endif

--- a/src/System.Net.IPNetwork/System.Net.IPNetwork.csproj
+++ b/src/System.Net.IPNetwork/System.Net.IPNetwork.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.1</TargetFrameworks> 
+    <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>IPNetwork2</PackageId>
     <PackageVersion>4.0.0</PackageVersion>

--- a/src/System.Net.IPNetwork/UniqueLocalAddress.cs
+++ b/src/System.Net.IPNetwork/UniqueLocalAddress.cs
@@ -179,7 +179,7 @@ public static class UniqueLocalAddress
         byte[] timestamp = BitConverter.GetBytes(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
         Array.Copy(timestamp, 0, input, macAddress.Length, timestamp.Length);
 
-#if NETSTANDARD2_1
+#if NETSTANDARD
         using var sha2 = SHA256.Create();
         byte[] hash = sha2.ComputeHash(input);
 #else
@@ -198,7 +198,7 @@ public static class UniqueLocalAddress
     private static byte[] GenerateGlobalIdFromSeed(string seed)
     {
         byte[] seedBytes = Encoding.UTF8.GetBytes(seed);
-#if NETSTANDARD2_1
+#if NETSTANDARD
         using var sha2 = SHA256.Create();
         byte[] hash = sha2.ComputeHash(seedBytes);
 #else

--- a/src/System.Net.IPNetwork/packages.lock.json
+++ b/src/System.Net.IPNetwork/packages.lock.json
@@ -1,6 +1,22 @@
 {
   "version": 1,
   "dependencies": {
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      }
+    },
     ".NETStandard,Version=v2.1": {},
     "net10.0": {},
     "net8.0": {},

--- a/src/TestProject/IPAddressExtensionTests.cs
+++ b/src/TestProject/IPAddressExtensionTests.cs
@@ -98,7 +98,14 @@ public class IPAddressExtensionTests
         foreach (int _ in Enumerable.Range(1, 1000))
         {
             /* Hash the current interation to get a new block of deterministic bytes. */
+#if NET5_0_OR_GREATER
             hashInput = SHA256.HashData(hashInput);
+#else
+            using (var sha = SHA256.Create())
+            {
+                hashInput = sha.ComputeHash(hashInput);
+            }
+#endif
 
             /* Convert the first n bytes for an address. 4 will have an IPv4. 16 will make an IPv6. */
             yield return new IPAddress(hashInput.Take(byteCount).ToArray()).ToString();

--- a/src/TestProject/TestProject.csproj
+++ b/src/TestProject/TestProject.csproj
@@ -16,6 +16,7 @@
         <WarningLevel>5</WarningLevel>
         <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
         <EnableMSTestRunner>true</EnableMSTestRunner>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/TestProject/TestProject.csproj
+++ b/src/TestProject/TestProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net10.0;net48</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <SignAssembly>True</SignAssembly>
         <SignAssembly Condition="'$(OS)' != 'Windows_NT'">true</SignAssembly>
@@ -49,8 +49,13 @@
         <Reference Include="System.Data" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\ConsoleApplication\ConsoleApplication.csproj" />
+        <ProjectReference Include="..\ConsoleApplication\ConsoleApplication.csproj" Condition="'$(TargetFramework)' == 'net10.0'" />
         <ProjectReference Include="..\System.Net.IPNetwork\System.Net.IPNetwork.csproj" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
+        <Compile Remove="ArchitectureTest.cs" />
+        <Compile Remove="ConsoleUnitTest.cs" />
+        <Compile Remove="ConsoleJsonOutputTest.cs" />
     </ItemGroup>
     <ItemGroup>
         <Compile Remove="TestResults\**" />

--- a/src/TestProject/packages.lock.json
+++ b/src/TestProject/packages.lock.json
@@ -1,6 +1,216 @@
 {
   "version": 1,
   "dependencies": {
+    ".NETFramework,Version=v4.8": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
+      },
+      "coverlet.msbuild": {
+        "type": "Direct",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "pmUxktztlMnsIvgHjzxG3fHRAXpqmZSA+W8dIsbVMfwI01SnBndrBIOE3Stg6987+o7HjBa62C4q5um3Ia6d9g=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Direct",
+        "requested": "[18.5.1, )",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.5.1, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
+      "MSTest.TestAdapter": {
+        "type": "Direct",
+        "requested": "[4.2.3, )",
+        "resolved": "4.2.3",
+        "contentHash": "oVV/luk0bBghnVvLaw8MwFlD7It0Cx9P2nKobeqIafmTQqFFWY69Wo801dxjeNaLzO/o9WQ84WSK84gXJuubhg==",
+        "dependencies": {
+          "MSTest.TestFramework": "4.2.3",
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.2.3",
+          "Microsoft.Testing.Platform.MSBuild": "2.2.3",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "MSTest.TestFramework": {
+        "type": "Direct",
+        "requested": "[4.2.3, )",
+        "resolved": "4.2.3",
+        "contentHash": "9zzij59YLh+tf+FRLNqhzHjmdspR91bol+jdQxLlxxTGMAML6LDbvuyXKMGdcrE84+QpKkk6KjTVBC5PBGrDeA==",
+        "dependencies": {
+          "MSTest.Analyzers": "4.2.3"
+        }
+      },
+      "NetArchTest.eNhancedEdition": {
+        "type": "Direct",
+        "requested": "[1.4.5, )",
+        "resolved": "1.4.5",
+        "contentHash": "dfWIjcLS2MBGz403OoT+vxr/4Dz/f7MnQhEwmgaf7PXlWzG39LSiUPhW7OPx9Ebg/GNWvDAttlpq5FY0mG/qkg==",
+        "dependencies": {
+          "Mono.Cecil": "0.11.6"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.4, )",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw==",
+        "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "5.0.0"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "2.2.3",
+        "contentHash": "mLdW+JOR3kXYGTdgR/qc/UZBA0r+eCR2k6bUxTcuDj5w9WdIQ7Lol5MBUU7YOSGd9bs9bvhSYWAptgz0YtQqCA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "2.2.3",
+          "System.Diagnostics.DiagnosticSource": "6.0.0"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.2.3",
+        "contentHash": "hntvxJEkmUAx6C2xXc/PO38DqEQl4rimzOgSvTR1hAMruMid7R4RcXOrzzF33J66gKaN7jRaQ0TMW/nNfaV9jw==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.2.3"
+        }
+      },
+      "Microsoft.Testing.Extensions.VSTestBridge": {
+        "type": "Transitive",
+        "resolved": "2.2.3",
+        "contentHash": "7WlJISO8QKUK+d+WhgnANwy4ACwUrvICnviY/mthPwjZ2gVeDaSUAeBnMy2cxfzZgm8VATtGUDbYzUxsgV2CyQ==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
+          "Microsoft.Testing.Extensions.Telemetry": "2.2.3",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.2.3",
+          "Microsoft.Testing.Platform": "2.2.3"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "2.2.3",
+        "contentHash": "LhM1/Qoi8Ams5QcD4r3f09CSOono9iQr3NEJQItFtyzWB55nWTgEOsVqXqMWWWIwk3nkPqc+XfnlJmp8xUI5fg=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "2.2.3",
+        "contentHash": "Q22jJYJLx4srTinsAuoCskqmzjrBJC8YeGJMHHIcrf1dQeHoEZ7wsqDzTlENkMoke2qfufF7U+9u58nlZunH/Q==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.2.3"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "AEIEX2aWdPO9XbtR96eBaJxmXRD9vaI9uQ1T/JbPEKlTAZwYx0ZrMzKyULMdh/HH9Sg03kXCoN7LszQ90o6nPQ==",
+        "dependencies": {
+          "System.Reflection.Metadata": "8.0.0"
+        }
+      },
+      "Mono.Cecil": {
+        "type": "Transitive",
+        "resolved": "0.11.6",
+        "contentHash": "f33RkDtZO8VlGXCtmQIviOtxgnUdym9xx/b1p9h91CRGOsJFxCFOFK1FDbVt1OCf1aWwYejUFa2MOQyFWTFjbA=="
+      },
+      "MSTest.Analyzers": {
+        "type": "Transitive",
+        "resolved": "4.2.3",
+        "contentHash": "dxOZt8/LWuiox7rugInJoIa5Mmu3pBmXdfaoZOx/mxx8+sUFFpjBXPlWXQXGeWzpkVPNC3x1Jf7rt2h2Zjyvvg=="
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "frQDfv0rl209cKm1lnwTgFPzNigy2EKk1BS3uAvHvlBVKe5cymGyHO+Sj+NLv5VF/AhHsqPIUUwya5oV4CHMUw==",
+        "dependencies": {
+          "System.Memory": "4.5.4",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0",
+          "System.Memory": "4.5.5"
+        }
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "IPNetwork2": {
+        "type": "Project"
+      }
+    },
     "net10.0": {
       "coverlet.collector": {
         "type": "Direct",


### PR DESCRIPTION
## Summary
- Re-enable `netstandard2.0` target on `System.Net.IPNetwork` (consumable from .NET Framework 4.6.1+ and other ns2.0 runtimes)
- Source compat: internal `NotNullWhenAttribute` polyfill, `SHA256.ComputeHash` fallback widened to all `NETSTANDARD`, `[^1]` indexer replaced, `Contains(char)` replaced with `IndexOf`
- Multi-target `TestProject` to `net10.0;net48` and add a `windows-latest` CI job — this is the only path that actually loads the ns2.0 DLL at runtime, gating regressions specific to the ns2.0 build
- CLI-coupled tests (`ArchitectureTest`, `ConsoleUnitTest`, `ConsoleJsonOutputTest`) excluded from the net48 build; they test the CLI (net10.0-only), not the library

## Test plan
- [x] `dotnet build src/System.Net.IPNetwork` succeeds for all 5 TFMs (net8/9/10, ns2.0, ns2.1)
- [x] `dotnet build src/TestProject` succeeds for net10.0 and net48
- [x] All 1364 tests pass on net10.0 locally
- [x] Verified the net48 TestProject output links the ns2.0 library DLL (byte-identical)
- [ ] Ubuntu CI green
- [ ] Windows net48 CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)